### PR TITLE
BorderPane Builder

### DIFF
--- a/src/main/java/tornadofx/Builders.kt
+++ b/src/main/java/tornadofx/Builders.kt
@@ -135,44 +135,24 @@ fun Pane.gridpane(op: (GridPane.() -> Unit)? = null) = opcr(this, GridPane(), op
 fun Pane.borderpane(op: (BorderPane.() -> Unit)? = null) = opcr(this,BorderPane(),op)
 
 fun BorderPane.top(op: Pane.() -> Unit) {
-    val pane: Pane = Pane()
-    op(pane)
-    val childCount = pane.children.size
-
-    when(childCount) {
-        1 -> top = pane.children[0]
-        in 1..1000 -> top = HBox().apply{ this.children.setAll(*pane.children.toTypedArray()) }
-    }
+    val vbox = VBox()
+    op(vbox)
+    top = if (vbox.children.size == 1) vbox.children[0] else vbox
 }
 fun BorderPane.bottom(op: Pane.() -> Unit) {
-    val pane: Pane = Pane()
-    op(pane)
-    val childCount = pane.children.size
-
-    when(childCount) {
-        1 -> bottom = pane.children[0]
-        in 1..1000 -> bottom = HBox().apply{ this.children.setAll(*pane.children.toTypedArray()) }
-    }
+    val vbox = VBox()
+    op(vbox)
+    bottom = if (vbox.children.size == 1) vbox.children[0] else vbox
 }
 fun BorderPane.left(op: Pane.() -> Unit) {
-    val pane: Pane = Pane()
-    op(pane)
-    val childCount = pane.children.size
-
-    when(childCount) {
-        1 -> left = pane.children[0]
-        in 1..1000 -> left = VBox().apply{ this.children.setAll(*pane.children.toTypedArray()) }
-    }
+    val vbox = VBox()
+    op(vbox)
+    left = if (vbox.children.size == 1) vbox.children[0] else vbox
 }
 fun BorderPane.right(op: Pane.() -> Unit) {
-    val pane: Pane = Pane()
-    op(pane)
-    val childCount = pane.children.size
-
-    when(childCount) {
-        1 -> right = pane.children[0]
-        in 1..1000 -> right = VBox().apply{ this.children.setAll(*pane.children.toTypedArray()) }
-    }
+    val vbox = VBox()
+    op(vbox)
+    right = if (vbox.children.size == 1) vbox.children[0] else vbox
 }
 
 /**

--- a/src/main/java/tornadofx/Builders.kt
+++ b/src/main/java/tornadofx/Builders.kt
@@ -134,19 +134,25 @@ fun Pane.stackpane(initialChildren: Iterable<Node>? = null, op: (StackPane.() ->
 fun Pane.gridpane(op: (GridPane.() -> Unit)? = null) = opcr(this, GridPane(), op)
 fun Pane.borderpane(op: (BorderPane.() -> Unit)? = null) = opcr(this,BorderPane(),op)
 
-//unsure what to do here
-fun BorderPane.top(title: String? = null, op: Pane.() -> Unit) {
-
+fun BorderPane.top(op: Pane.() -> Unit) {
+    val pane: Pane = Pane()
+    op(pane)
+    this.top = pane.children[0]
 }
-
-fun BorderPane.bottom(title: String? = null, op: Pane.() -> Unit) {
-
+fun BorderPane.bottom(op: Pane.() -> Unit) {
+    val pane: Pane = Pane()
+    op(pane)
+    this.bottom = pane.children[0]
 }
-fun BorderPane.left(title: String? = null, op: Pane.() -> Unit) {
-
+fun BorderPane.left(op: Pane.() -> Unit) {
+    val pane: Pane = Pane()
+    op(pane)
+    this.left = pane.children[0]
 }
-fun BorderPane.right(title: String? = null, op: Pane.() -> Unit) {
-
+fun BorderPane.right(op: Pane.() -> Unit) {
+    val pane: Pane = Pane()
+    op(pane)
+    this.right = pane.children[0]
 }
 
 /**

--- a/src/main/java/tornadofx/Builders.kt
+++ b/src/main/java/tornadofx/Builders.kt
@@ -137,22 +137,42 @@ fun Pane.borderpane(op: (BorderPane.() -> Unit)? = null) = opcr(this,BorderPane(
 fun BorderPane.top(op: Pane.() -> Unit) {
     val pane: Pane = Pane()
     op(pane)
-    this.top = pane.children[0]
+    val childCount = pane.children.size
+
+    when(childCount) {
+        1 -> top = pane.children[0]
+        in 1..1000 -> top = HBox().apply{ this.children.setAll(*pane.children.toTypedArray()) }
+    }
 }
 fun BorderPane.bottom(op: Pane.() -> Unit) {
     val pane: Pane = Pane()
     op(pane)
-    this.bottom = pane.children[0]
+    val childCount = pane.children.size
+
+    when(childCount) {
+        1 -> bottom = pane.children[0]
+        in 1..1000 -> bottom = HBox().apply{ this.children.setAll(*pane.children.toTypedArray()) }
+    }
 }
 fun BorderPane.left(op: Pane.() -> Unit) {
     val pane: Pane = Pane()
     op(pane)
-    this.left = pane.children[0]
+    val childCount = pane.children.size
+
+    when(childCount) {
+        1 -> left = pane.children[0]
+        in 1..1000 -> left = VBox().apply{ this.children.setAll(*pane.children.toTypedArray()) }
+    }
 }
 fun BorderPane.right(op: Pane.() -> Unit) {
     val pane: Pane = Pane()
     op(pane)
-    this.right = pane.children[0]
+    val childCount = pane.children.size
+
+    when(childCount) {
+        1 -> right = pane.children[0]
+        in 1..1000 -> right = VBox().apply{ this.children.setAll(*pane.children.toTypedArray()) }
+    }
 }
 
 /**

--- a/src/main/java/tornadofx/Builders.kt
+++ b/src/main/java/tornadofx/Builders.kt
@@ -44,6 +44,7 @@ fun GridPane.row(title: String? = null, op: Pane.() -> Unit) {
     addRow(userData as Int, *fake.children.toTypedArray())
 }
 
+
 fun Pane.text(initialValue: String? = null, op: (Text.() -> Unit)? = null) = opcr(this, Text().apply { if (initialValue != null) text = initialValue }, op)
 fun Pane.text(property: Property<String>, op: (Text.() -> Unit)? = null) = text(op = op).apply {
     textProperty().bindBidirectional(property)
@@ -131,6 +132,22 @@ fun Pane.vbox(spacing: Double? = null, children: Iterable<Node>? = null, op: (VB
 
 fun Pane.stackpane(initialChildren: Iterable<Node>? = null, op: (StackPane.() -> Unit)? = null) = opcr(this, StackPane().apply { if (initialChildren != null) children.addAll(initialChildren) }, op)
 fun Pane.gridpane(op: (GridPane.() -> Unit)? = null) = opcr(this, GridPane(), op)
+fun Pane.borderpane(op: (BorderPane.() -> Unit)? = null) = opcr(this,BorderPane(),op)
+
+//unsure what to do here
+fun BorderPane.top(title: String? = null, op: Pane.() -> Unit) {
+
+}
+
+fun BorderPane.bottom(title: String? = null, op: Pane.() -> Unit) {
+
+}
+fun BorderPane.left(title: String? = null, op: Pane.() -> Unit) {
+
+}
+fun BorderPane.right(title: String? = null, op: Pane.() -> Unit) {
+
+}
 
 /**
  * Add the given node to the pane, invoke the node operation and return the node

--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -6,6 +6,7 @@ import javafx.collections.ObservableList
 import javafx.event.EventTarget
 import javafx.geometry.HPos
 import javafx.geometry.Insets
+import javafx.geometry.Pos
 import javafx.geometry.VPos
 import javafx.scene.Node
 import javafx.scene.Scene
@@ -250,6 +251,25 @@ fun EventTarget.isInsideTableRow(): Boolean {
     return false
 }
 
+/**
+ * Access BorderPane constraints to manipulate and apply on this control
+ */
+fun <T : Node> T.borderpaneConstraints(op:(BorderPaneConstraint.() -> Unit)): T {
+    val bpc = BorderPaneConstraint()
+    bpc.op()
+    return bpc.applyToNode(this)
+}
+
+class BorderPaneConstraint(
+    var margin: Insets? = null,
+    var alignment: Pos? = null
+) {
+    fun <T : Node> applyToNode(node: T): T {
+        margin?.let { BorderPane.setMargin(node,it) }
+        alignment?.let { BorderPane.setAlignment(node,it) }
+        return node
+    }
+}
 
 /**
  * Access GridPane constraints to manipulate and apply on this control


### PR DESCRIPTION
I'm trying to implement `BorderPane` builders and get something to this effect.

```kotlin

class BorderPaneTest : App() {

    override val primaryView = BorderPaneItem::class

}

class BorderPaneItem() : View() {
    override val root = BorderPane()
    init {
        with(root) {
            top {
                button("Top") {
                    borderpaneConstraints {
                        alignment = Pos.TOP_CENTER
                    }
                }
            }
            bottom {
                button("Bottom") {
                    borderpaneConstraints {
                        alignment = Pos.TOP_LEFT
                    }
                }
            }
            left {
                button("Left") {
                    borderpaneConstraints {
                        alignment = Pos.TOP_LEFT
                    }
                }
            }
            right {
                button("Right") {
                    borderpaneConstraints {
                        alignment = Pos.BOTTOM_RIGHT
                    }
                }
            }
        }
    }
}
```

I'm getting the "dupe children" issue and I think this has to do with builders adding the elements twice due to a parent inadvertently getting targeted. I think you did some sort of trick with the `GridPane` builder by using some "fake" `Pane`. 

What do you think?