### PR TITLE
Implement SingleAssign functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `singleAssign()` property delegates (https://github.com/edvin/tornadofx/issues/17)
+- Tests for `singleAssign()`
+
+### Added
 - BorderPane builder (https://github.com/edvin/tornadofx/pull/16)
 - `Node.gridpaneConstraints` extension function (https://github.com/edvin/tornadofx/issues/12)
 - `Node.vboxConstraints` extension function

--- a/src/main/java/tornadofx/Properties.kt
+++ b/src/main/java/tornadofx/Properties.kt
@@ -29,3 +29,66 @@ fun <T> Any.getProperty(prop: KMutableProperty1<*, T>): ObjectProperty<T> {
     val delegate = field.get(this) as PropertyDelegate<T>
     return delegate.fxProperty as ObjectProperty<T>
 }
+
+enum class SingleAssignThreadSafetyMode {
+    SYNCHRONIZED,
+    NONE
+}
+
+fun <T> singleAssign(threadSafeyMode: SingleAssignThreadSafetyMode = SingleAssignThreadSafetyMode.SYNCHRONIZED): SingleAssign<T> =
+    if (threadSafeyMode.equals(SingleAssignThreadSafetyMode.SYNCHRONIZED)) SynchronizedSingleAssign<T>() else UnsynchronizedSingleAssign<T>()
+
+private object UNINITIALIZED_VALUE
+
+interface SingleAssign<T> {
+    fun isInitialized(): Boolean
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): T
+    operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T)
+}
+
+private class SynchronizedSingleAssign<T>: SingleAssign<T> {
+
+    @Volatile
+    private var initialized = false
+
+    @Volatile
+    private var _value: Any? = UNINITIALIZED_VALUE
+
+    override operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        if (!initialized)
+            throw Exception("Value has not been assigned yet!")
+        return _value as T
+    }
+
+    override operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        synchronized(this) {
+            if (initialized) {
+                throw Exception("Value has already been assigned!")
+            }
+            _value = value as T
+            initialized = true
+        }
+    }
+    override fun isInitialized() = initialized
+}
+
+private class UnsynchronizedSingleAssign<T>: SingleAssign<T> {
+
+    private var initialized = false
+    private var _value: Any? = UNINITIALIZED_VALUE
+
+    override operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        if (!initialized)
+            throw Exception("Value has not been assigned yet!")
+        return _value as T
+    }
+
+    override operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        if (initialized) {
+            throw Exception("Value has already been assigned!")
+        }
+        _value = value as T
+        initialized = true
+    }
+    override fun isInitialized() = initialized
+}

--- a/src/main/java/tornadofx/Properties.kt
+++ b/src/main/java/tornadofx/Properties.kt
@@ -48,3 +48,66 @@ fun <S, T> observable(owner: S, prop: KProperty1<S, T>): ReadOnlyObjectProperty<
         override fun get() = prop.get(owner)
     }
 }
+
+enum class SingleAssignThreadSafetyMode {
+    SYNCHRONIZED,
+    NONE
+}
+
+fun <T> singleAssign(threadSafeyMode: SingleAssignThreadSafetyMode = SingleAssignThreadSafetyMode.SYNCHRONIZED): SingleAssign<T> =
+        if (threadSafeyMode.equals(SingleAssignThreadSafetyMode.SYNCHRONIZED)) SynchronizedSingleAssign<T>() else UnsynchronizedSingleAssign<T>()
+
+private object UNINITIALIZED_VALUE
+
+interface SingleAssign<T> {
+    fun isInitialized(): Boolean
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): T
+    operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T)
+}
+
+private class SynchronizedSingleAssign<T>: SingleAssign<T> {
+
+    @Volatile
+    private var initialized = false
+
+    @Volatile
+    private var _value: Any? = UNINITIALIZED_VALUE
+
+    override operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        if (!initialized)
+            throw Exception("Value has not been assigned yet!")
+        return _value as T
+    }
+
+    override operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        synchronized(this) {
+            if (initialized) {
+                throw Exception("Value has already been assigned!")
+            }
+            _value = value as T
+            initialized = true
+        }
+    }
+    override fun isInitialized() = initialized
+}
+
+private class UnsynchronizedSingleAssign<T>: SingleAssign<T> {
+
+    private var initialized = false
+    private var _value: Any? = UNINITIALIZED_VALUE
+
+    override operator fun getValue(thisRef: Any?, property: KProperty<*>): T {
+        if (!initialized)
+            throw Exception("Value has not been assigned yet!")
+        return _value as T
+    }
+
+    override operator fun setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+        if (initialized) {
+            throw Exception("Value has already been assigned!")
+        }
+        _value = value as T
+        initialized = true
+    }
+    override fun isInitialized() = initialized
+}

--- a/src/test/kotlin/tornadofx/PropertiesTest.kt
+++ b/src/test/kotlin/tornadofx/PropertiesTest.kt
@@ -2,6 +2,7 @@ package tornadofx
 
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class PropertiesTest {
 
@@ -42,5 +43,41 @@ class PropertiesTest {
         assertEquals(42, fixture.integer)
         assertEquals(42, fixture.integerDefault)
     }
+    class TestClass {
+        var myProperty: String by singleAssign()
+    }
 
+    @Test
+    fun failNoAssignment() {
+        val instance = TestClass()
+        var failed = false
+
+        try {
+            val extract = instance.myProperty
+        } catch (e: Exception) {
+            failed = true
+        }
+        assertTrue(failed)
+    }
+    @Test
+    fun succeedAssignment() {
+        val instance = TestClass()
+        var failed = false
+        instance.myProperty = "foo"
+        val extract = instance.myProperty
+    }
+    @Test
+    fun failDoubleAssignment() {
+
+        val instance = TestClass()
+        var failed = false
+        instance.myProperty = "foo"
+
+        try {
+            instance.myProperty = "bar"
+        } catch (e: Exception) {
+            failed = true
+        }
+        assertTrue(failed)
+    }
 }


### PR DESCRIPTION
Please refer to #17.

Let me know if the synchronization `enum` argument name is too long or if you need unit tests.

```kotlin

class MainApp : App() {
    override val primaryView = MainView::class

    class MainView : View() {
        override val root = GridPane()

        var testVar: String by singleAssign()
        // can also be called with argument singleAssign(SingleAssignThreadSafetyMode.SYNCHRONIZED)
        // or singleAssign(SingleAssignThreadSafetyMode.NONE)
        
        init {

            //CASE 1
            println(testVar) //fails correctly

            //CASE 2
            testVar = "Hello"
            println(testVar)
            testVar = "World" //fails correctly

            //CASE 3
            testVar ="Hello"
            println(testVar) //no issues
        }
    }
}
```