### PR TITLE
Max height/width constraints for layout builders

### DIFF
--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -289,8 +289,16 @@ class GridPaneConstraint(
         var fillHeight: Boolean? = null,
         var fillWidth: Boolean? = null,
         var hAlignment: HPos? = null,
-        var vAlignment: VPos? = null
+        var vAlignment: VPos? = null,
+        var useMaxWidth: Boolean? = null,
+        var useMaxHeight: Boolean? = null
 ) {
+    var useMaxHeightWidth: Boolean? = null
+        set(value) {
+            useMaxWidth = value
+            useMaxHeight = value
+            field = value
+        }
     var vhGrow: Priority? = null
         set(value) {
             vGrow = value
@@ -325,6 +333,8 @@ class GridPaneConstraint(
         fillWidth?.let { GridPane.setFillWidth(node, it) }
         hAlignment?.let { GridPane.setHalignment(node, it) }
         vAlignment?.let { GridPane.setValignment(node, it) }
+        useMaxWidth?.let { if (node is Region && it) node.maxWidth = Double.MAX_VALUE }
+        useMaxHeight?.let { if (node is Region && it) node.maxHeight = Double.MAX_VALUE }
         return node
     }
 }
@@ -337,11 +347,21 @@ fun <T : Node> T.vboxConstraints(op: (VBoxConstraint.() -> Unit)): T {
 
 class VBoxConstraint(
         var margin: Insets? = null,
-        var vGrow: Priority? = null
+        var vGrow: Priority? = null,
+        var useMaxWidth: Boolean? = null,
+        var useMaxHeight: Boolean? = null
 ) {
+    var useMaxHeightWidth: Boolean? = null
+        set(value) {
+            useMaxWidth = value
+            useMaxHeight = value
+            field = value
+        }
     fun <T : Node> applyToNode(node: T): T {
         margin?.let { VBox.setMargin(node, it) }
         vGrow?.let { VBox.setVgrow(node, it) }
+        useMaxWidth?.let { if (node is Region && it) node.maxWidth = Double.MAX_VALUE }
+        useMaxHeight?.let { if (node is Region && it) node.maxHeight = Double.MAX_VALUE }
         return node
     }
 }
@@ -354,11 +374,21 @@ fun <T : Node> T.hboxConstraints(op: (HBoxConstraint.() -> Unit)): T {
 
 class HBoxConstraint(
         var margin: Insets? = null,
-        var hGrow: Priority? = null
+        var hGrow: Priority? = null,
+        var useMaxWidth: Boolean? = null,
+        var useMaxHeight: Boolean? = null
 ) {
+    var useMaxHeightWidth: Boolean? = null
+        set(value) {
+            useMaxWidth = value
+            useMaxHeight = value
+            field = value
+        }
     fun <T : Node> applyToNode(node: T): T {
         margin?.let { HBox.setMargin(node, it) }
         hGrow?.let { HBox.setHgrow(node, it) }
+        useMaxWidth?.let { if (node is Region && it) node.maxWidth = Double.MAX_VALUE }
+        useMaxHeight?.let { if (node is Region && it) node.maxHeight = Double.MAX_VALUE }
         return node
     }
 }


### PR DESCRIPTION
`GridPane`,`VBox`, and `HBox` really need constraint parameters to use the max width, max height, or both. They're not natively part of these layouts but they would be a welcome enhancement to me. What do you think? 

**No useMaxWidth**
![1](https://cloud.githubusercontent.com/assets/7420801/13342214/00022952-dc05-11e5-815e-3a669639e62e.png)

**With useMaxWidth**
![2](https://cloud.githubusercontent.com/assets/7420801/13342213/0000495c-dc05-11e5-9d4c-3f9cdd392f60.png)

```kotlin
class BorderPaneItem() : View() {
    override val root = GridPane()
    init {
        with(root) {
            button("Button").gridpaneConstraints {
                columnRowIndex(0,0)
                useMaxWidth = true
            }
            button("Another Button").gridpaneConstraints {
                columnRowIndex(0,1)
                useMaxWidth = true
            }
        }
    }
}
```

