### PR TITLE
Add TableCell rowItem extension property

### DIFF
--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -176,6 +176,8 @@ fun <T> TableView<T>.onUserSelect(clickCount: Int = 2, action: (T) -> Unit) {
     }
 }
 
+val <S,T> TableCell<S,T>.rowItem:S get() = tableView.items[index]
+
 fun <T> TableView<T>.asyncItems(func: () -> ObservableList<T>) =
     task { func() } success { if (items == null) items = it else items.setAll(it) }
 


### PR DESCRIPTION
Refer to #11. Would it be okay to add a `rowItem` extension property for this? I think it might be useful especially when using `cellFormat()`. 