### PR TITLE
Make the gpg signing only happen when mvn deploy is being done

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>


### PR DESCRIPTION
I needed the `by fxml(filename)` functionality. Doing mvn install kicks of the gpg signing. Usually this is during the deploy phase