### PR TITLE
Created a TableView.column extension that uses a PropertyValueFactory…

### DIFF
--- a/src/main/java/tornadofx/Builders.kt
+++ b/src/main/java/tornadofx/Builders.kt
@@ -284,6 +284,16 @@ fun <S, T> TableView<S>.column(title: String, valueProvider: (TableColumn.CellDa
     return column
 }
 
+/**
+ * Create a column with a PropertyValueFactory as valueProvider
+ */
+fun <S, T> TableView<S>.column(title: String, valueProvider: PropertyValueFactory<S, T>): TableColumn<S, T> {
+    val column = TableColumn<S, T>(title)
+    column.cellValueFactory = valueProvider
+    columns.add(column)
+    return column
+}
+
 fun <S, T> TableColumn<S, T?>.makeComboBox(items: ObservableList<T>, afterCommit: ((TableColumn.CellEditEvent<S, T?>) -> Unit)? = null): TableColumn<S, T?> {
     cellFactory = ComboBoxTableCell.forTableColumn(items)
     setOnEditCommit {

--- a/src/main/java/tornadofx/Builders.kt
+++ b/src/main/java/tornadofx/Builders.kt
@@ -285,11 +285,11 @@ fun <S, T> TableView<S>.column(title: String, valueProvider: (TableColumn.CellDa
 }
 
 /**
- * Create a column with a PropertyValueFactory as valueProvider
+ * Create a column using the propertyName of the attribute you want shown.
  */
-fun <S, T> TableView<S>.column(title: String, valueProvider: PropertyValueFactory<S, T>): TableColumn<S, T> {
+fun <S, T> TableView<S>.column(title: String, propertyName: String): TableColumn<S, T> {
     val column = TableColumn<S, T>(title)
-    column.cellValueFactory = valueProvider
+    column.cellValueFactory = PropertyValueFactory<S, T>(propertyName)
     columns.add(column)
     return column
 }


### PR DESCRIPTION
Created a TableView.column extension that uses a PropertyValueFactory as provider. This way you can easily hook up POJO's.

It can be used like this:
````
override val root = TableView<CategoryStory>()

    init {
        with(root) {
            column("Title", PropertyValueFactory<CategoryStory, String>("name"))
            column("Types", PropertyValueFactory<CategoryStory, String>("types"))
        }
    }
````