### PR TITLE
Added AnchorPane support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - `TableColumn.enableTextWrap` (https://github.com/edvin/tornadofx/pull/65)
 - `TableColumn` cell factory that wraps `PropertyValueFactory` for better POJO support (https://github.com/edvin/tornadofx/pull/75)
 - `splitpane` builder (https://github.com/edvin/tornadofx/issues/72)
+- `anchorpane` builder (https://github.com/edvin/tornadofx/issues/84)
 - `accordion` builder (https://github.com/edvin/tornadofx/pull/73)
 - `JsonStructure.toPrettyString` (https://github.com/edvin/tornadofx/pull/77)
 - `text` builder (https://github.com/edvin/tornadofx/issues/76)

--- a/src/main/java/tornadofx/Builders.kt
+++ b/src/main/java/tornadofx/Builders.kt
@@ -189,6 +189,15 @@ fun SplitPane.items(op: (Pane.() -> Unit)) {
     items.addAll(fake.children)
 }
 
+fun Pane.anchorpane(vararg nodes: Node, op: (AnchorPane.() -> Unit)? = null): AnchorPane {
+    val anchorpane = AnchorPane()
+    if (nodes.isNotEmpty()) {
+        anchorpane.children.addAll(nodes)
+    }
+    opcr(this, anchorpane, op)
+    return anchorpane
+}
+
 fun Pane.accordion(vararg panes: TitledPane, op: (Accordion.() -> Unit)? = null): Accordion {
     var accordion = Accordion()
     if (panes.isNotEmpty())

--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -471,6 +471,27 @@ class HBoxConstraint(
     }
 }
 
+fun <T: Node> T.anchorpaneConstraints(op: AnchorPaneConstraint.() -> Unit): T {
+    val c = AnchorPaneConstraint()
+    c.op()
+    return c.applyToNode(this)
+}
+
+class AnchorPaneConstraint(
+        var topAnchor: Double? = null,
+        var rightAnchor: Double? = null,
+        var bottomAnchor: Double? = null,
+        var leftAnchor: Double? = null
+) {
+    fun <T : Node> applyToNode(node: T): T {
+        topAnchor?.let { AnchorPane.setTopAnchor(node, it) }
+        rightAnchor?.let { AnchorPane.setRightAnchor(node, it) }
+        bottomAnchor?.let { AnchorPane.setBottomAnchor(node, it) }
+        leftAnchor?.let { AnchorPane.setLeftAnchor(node, it) }
+        return node
+    }
+}
+
 abstract class MarginableConstraints {
     abstract var margin: Insets
     var marginTop: Double


### PR DESCRIPTION
For issue #84

Demo:

```kotlin
class ControlsTest : SingleViewApp("Controls Test") {
    override val root = AnchorPane()

    init {
        with(root) {
            prefHeight = 300.0
            prefWidth = 400.0
            padding = Insets(8.0)

            label("left: 10, top: 100") {
                anchorpaneConstraints {
                    leftAnchor = 10.0
                    topAnchor = 100.0
                }
            }
            label("right: 100, top: 10") {
                anchorpaneConstraints {
                    topAnchor = 10.0
                    rightAnchor = 100.0
                }
            }
            label("right: 10, bottom: 100") {
                anchorpaneConstraints {
                    rightAnchor = 10.0
                    bottomAnchor = 100.0
                }
            }
            label("left: 100, bottom: 10") {
                anchorpaneConstraints {
                    bottomAnchor = 10.0
                    leftAnchor = 100.0
                }
            }
        }
    }
}
```

![anchorpane-test](https://cloud.githubusercontent.com/assets/1735659/14475882/aad9a02c-00c1-11e6-8975-884c66155ab8.png)