### PR TITLE
Added a function to add a separator to a contextMenu

### DIFF
--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -49,14 +49,14 @@ fun ContextMenu.menuitem(name: String, keyCombination: KeyCombination? = null, g
 /**
  * Add a separator to the contextmenu
  */
-fun ContextMenu.separator(op: (SeparatorMenuItem.()->Unit)){
+fun ContextMenu.separator(op: (SeparatorMenuItem.()->Unit)? = null){
     val separator = SeparatorMenuItem()
     separator.op()
     this+=separator
 }
 
 //Menu extensions
-fun Menu.menu(name: String? = null, op: (Menu.() -> Unit)?=null): Menu {
+fun Menu.menu(name: String? = null, op: (Menu.() -> Unit)): Menu {
     val menu = Menu(name)
     menu.op()
     this += menu

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -56,7 +56,7 @@ fun ContextMenu.separator(op: (SeparatorMenuItem.()->Unit)){
 }
 
 //Menu extensions
-fun Menu.menu(name: String? = null, op: (Menu.() -> Unit)): Menu {
+fun Menu.menu(name: String? = null, op: (Menu.() -> Unit)?=null): Menu {
     val menu = Menu(name)
     menu.op()
     this += menu

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -46,6 +46,13 @@ fun ContextMenu.menuitem(name: String, keyCombination: KeyCombination? = null, g
     return menuItem
 }
 
+/**
+ * Add a separator to the contextmenu
+ */
+fun ContextMenu.separator(){
+    this+=SeparatorMenuItem()
+}
+
 //Menu extensions
 fun Menu.menu(name: String? = null, op: (Menu.() -> Unit)): Menu {
     val menu = Menu(name)

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -51,7 +51,7 @@ fun ContextMenu.menuitem(name: String, keyCombination: KeyCombination? = null, g
  */
 fun ContextMenu.separator(op: (SeparatorMenuItem.()->Unit)? = null){
     val separator = SeparatorMenuItem()
-    separator.op()
+    op?.invoke(separator)
     this+=separator
 }
 

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -49,8 +49,10 @@ fun ContextMenu.menuitem(name: String, keyCombination: KeyCombination? = null, g
 /**
  * Add a separator to the contextmenu
  */
-fun ContextMenu.separator(){
-    this+=SeparatorMenuItem()
+fun ContextMenu.separator(op: (SeparatorMenuItem.()->Unit)){
+    val separator = SeparatorMenuItem()
+    separator.op()
+    this+=separator
 }
 
 //Menu extensions


### PR DESCRIPTION
Its quite normal to be able to add a separator to a context menu
<img width="141" alt="screenshot 2016-05-02 21 35 10" src="https://cloud.githubusercontent.com/assets/595350/14965449/d000d694-10ad-11e6-96c3-68d0355cd60f.png">
