### PR TITLE
Dimension Arithmetic

### DIFF
--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -811,7 +811,18 @@ class CssPropertyDelegate<T : Any>(val name: String?, val multiValue: Boolean) :
 // Dimensions
 
 open class Dimension<T : Enum<T>>(val value: Double, val units: T) {
+    operator fun unaryPlus() = this
     operator fun unaryMinus() = Dimension(-value, units)
+    operator fun plus(value: Number) = Dimension(this.value + value.toDouble(), units)
+    operator fun plus(value: Dimension<T>) = if (units == value.units) Dimension(this.value + value.value, units) else throw IllegalArgumentException("Cannot add $this and $value: Units do not match")
+    operator fun minus(value: Number) = Dimension(this.value - value.toDouble(), units)
+    operator fun minus(value: Dimension<T>) = if (units == value.units) Dimension(this.value - value.value, units) else throw IllegalArgumentException("Cannot subtract $value from $this: Units do not match")
+    operator fun times(value: Number) = Dimension(this.value * value.toDouble(), units)
+    operator fun div(value: Number) = Dimension(this.value / value.toDouble(), units)
+
+    override fun equals(other: Any?) = other != null && other is Dimension<*> && value == other.value && units == other.units
+    override fun hashCode() = value.hashCode() * 31 + units.hashCode()
+
     override fun toString() = when (value) {
         Double.POSITIVE_INFINITY, Double.MAX_VALUE -> "infinity"
         Double.NEGATIVE_INFINITY, Double.MIN_VALUE -> "-infinity"
@@ -834,6 +845,10 @@ open class Dimension<T : Enum<T>>(val value: Double, val units: T) {
         override fun toString() = value
     }
 }
+
+operator fun <T : Enum<T>> Number.plus(value: Dimension<T>) = Dimension(this.toDouble() + value.value, value.units)
+operator fun <T : Enum<T>> Number.minus(value: Dimension<T>) = Dimension(this.toDouble() - value.value, value.units)
+operator fun <T : Enum<T>> Number.times(value: Dimension<T>) = Dimension(this.toDouble() * value.value, value.units)
 
 val infinity = Dimension(Double.POSITIVE_INFINITY, Dimension.LinearUnits.px)
 

--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -814,11 +814,16 @@ open class Dimension<T : Enum<T>>(val value: Double, val units: T) {
     operator fun unaryPlus() = this
     operator fun unaryMinus() = Dimension(-value, units)
     operator fun plus(value: Number) = Dimension(this.value + value.toDouble(), units)
-    operator fun plus(value: Dimension<T>) = if (units == value.units) Dimension(this.value + value.value, units) else throw IllegalArgumentException("Cannot add $this and $value: Units do not match")
+    operator fun plus(value: Dimension<T>) = safeMath(value, Double::plus)
     operator fun minus(value: Number) = Dimension(this.value - value.toDouble(), units)
-    operator fun minus(value: Dimension<T>) = if (units == value.units) Dimension(this.value - value.value, units) else throw IllegalArgumentException("Cannot subtract $value from $this: Units do not match")
+    operator fun minus(value: Dimension<T>) = safeMath(value, Double::minus)
     operator fun times(value: Number) = Dimension(this.value * value.toDouble(), units)
     operator fun div(value: Number) = Dimension(this.value / value.toDouble(), units)
+
+    private fun safeMath(value: Dimension<T>, op: (Double, Double) -> Double) = if (units == value.units)
+        Dimension(op(this.value, value.value), units)
+    else
+        throw IllegalArgumentException("Cannot combine $this and $value: Units do not match")
 
     override fun equals(other: Any?) = other != null && other is Dimension<*> && value == other.value && units == other.units
     override fun hashCode() = value.hashCode() * 31 + units.hashCode()

--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -819,6 +819,7 @@ open class Dimension<T : Enum<T>>(val value: Double, val units: T) {
     operator fun minus(value: Dimension<T>) = safeMath(value, Double::minus)
     operator fun times(value: Number) = Dimension(this.value * value.toDouble(), units)
     operator fun div(value: Number) = Dimension(this.value / value.toDouble(), units)
+    operator fun mod(value: Number) = Dimension(this.value % value.toDouble(), units)
 
     private fun safeMath(value: Dimension<T>, op: (Double, Double) -> Double) = if (units == value.units)
         Dimension(op(this.value, value.value), units)

--- a/src/test/kotlin/tornadofx/StylesheetTests.kt
+++ b/src/test/kotlin/tornadofx/StylesheetTests.kt
@@ -51,6 +51,8 @@ class StylesheetTests {
         assert(8.px == base - num)
         assert(20.px == base * num)
         assert(5.px == base / num)
+        assert(0.px == base % num)
+        assert(3.px == base % 7)
 
         assert(12.px == base + dim)
         assert(8.px == base - dim)

--- a/src/test/kotlin/tornadofx/StylesheetTests.kt
+++ b/src/test/kotlin/tornadofx/StylesheetTests.kt
@@ -11,6 +11,7 @@ import tornadofx.Stylesheet.Companion.hover
 import tornadofx.Stylesheet.Companion.label
 import tornadofx.Stylesheet.Companion.star
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 
 class StylesheetTests {
     val vbox by cssclass()
@@ -36,6 +37,31 @@ class StylesheetTests {
     val lumpyId by cssid()
     val lumpyClass by cssclass()
     val lumpyPseudoClass by csspseudoclass()
+
+    @Test
+    fun dimensionalAnalysis() {
+        val base = 10.px
+        val num = 2
+        val dim = 2.px
+        val disjoint = 5.mm
+
+        assert((-10).px == -base)
+
+        assert(12.px == base + num)
+        assert(8.px == base - num)
+        assert(20.px == base * num)
+        assert(5.px == base / num)
+
+        assert(12.px == base + dim)
+        assert(8.px == base - dim)
+
+        assert(12.px == num + base)
+        assert(-8.px == num - base)
+        assert(20.px == num * base)
+
+        assertFails { base + disjoint }
+        assertFails { base - disjoint }
+    }
 
     @Test
     fun unsafeProperties() {


### PR DESCRIPTION
Expressions that would result it unsupported units or no units were not implemented. For example, you can only multiply and divide with numbers, and you can only divide a dimension by a number (not the other way around). Additionally, addition and subtraction require the same unit or an exception is thrown.