### PR TITLE
Added ability to add icon to App in constructor

### DIFF
--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -9,8 +9,8 @@ import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
-open class App(primaryView: KClass<out View>? = null, icon: Image? = null, vararg stylesheet: KClass<out Stylesheet>) : Application() {
-    constructor(primaryView: KClass<out View>? = null, vararg stylesheet: KClass<out Stylesheet>) : this(primaryView, null, *stylesheet)
+open class App(icon: Image? = null, primaryView: KClass<out View>? = null, vararg stylesheet: KClass<out Stylesheet>) : Application() {
+    constructor(primaryView: KClass<out View>? = null, vararg stylesheet: KClass<out Stylesheet>) : this(null, primaryView, *stylesheet)
 
     open val primaryView: KClass<out View> = primaryView ?: DeterminedByParameter::class
 

--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -2,16 +2,20 @@ package tornadofx
 
 import javafx.application.Application
 import javafx.scene.Scene
+import javafx.scene.image.Image
 import javafx.scene.layout.Pane
 import javafx.stage.Stage
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
-open class App(primaryView: KClass<out View>? = null, vararg stylesheet: KClass<out Stylesheet>) : Application() {
+open class App(primaryView: KClass<out View>? = null, icon: Image? = null, vararg stylesheet: KClass<out Stylesheet>) : Application() {
+    constructor(primaryView: KClass<out View>? = null, vararg stylesheet: KClass<out Stylesheet>) : this(primaryView, null, *stylesheet)
+
     open val primaryView: KClass<out View> = primaryView ?: DeterminedByParameter::class
 
     init {
+        icon?.let { addStageIcon(it) }
         stylesheet.forEach { importStylesheet(it) }
     }
 

--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -9,13 +9,14 @@ import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
-open class App(icon: Image? = null, primaryView: KClass<out View>? = null, vararg stylesheet: KClass<out Stylesheet>) : Application() {
-    constructor(primaryView: KClass<out View>? = null, vararg stylesheet: KClass<out Stylesheet>) : this(null, primaryView, *stylesheet)
+open class App(primaryView: KClass<out View>? = null, vararg stylesheet: KClass<out Stylesheet>) : Application() {
+    constructor(icon: Image, primaryView: KClass<out View>? = null, vararg stylesheet: KClass<out Stylesheet>) : this(primaryView, *stylesheet) {
+        addStageIcon(icon)
+    }
 
     open val primaryView: KClass<out View> = primaryView ?: DeterminedByParameter::class
 
     init {
-        icon?.let { addStageIcon(it) }
         stylesheet.forEach { importStylesheet(it) }
     }
 


### PR DESCRIPTION
It would be possible to do this with a single constructor, but it would feel funny. If you put the icon after the stylesheets, you always have to say `icon = Image("path/to/image")` instead of just `Image("path/to/image")`, whereas if you put it before you have to do the same with the stylesheets. This way makes if feel a little cleaner.