### PR TITLE
Make the methods 'bind' accepting nullable properties

### DIFF
--- a/src/main/java/tornadofx/Binding.kt
+++ b/src/main/java/tornadofx/Binding.kt
@@ -17,6 +17,8 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.*
 import java.util.concurrent.Callable
+import kotlin.reflect.KClass
+import kotlin.reflect.jvm.jvmName
 
 inline fun <reified T> ComboBoxBase<T>.bind(property: Property<T>, readonly: Boolean = false) =
     if (readonly) valueProperty().bind(property) else valueProperty().bindBidirectional(property)
@@ -36,19 +38,19 @@ fun CheckBox.bind(property: Property<Boolean>, readonly: Boolean = false) =
 fun Slider.bind(property: Property<Number>, readonly: Boolean = false) =
     if (readonly) valueProperty().bind(property) else valueProperty().bindBidirectional(property)
 
-inline fun <reified T : Any> Labeled.bind(property: Property<T>, readonly: Boolean = false, converter: StringConverter<T>? = null, format: Format? = null) =
+inline fun <reified T> Labeled.bind(property: Property<T>, readonly: Boolean = false, converter: StringConverter<T>? = null, format: Format? = null) =
         bindStringProperty(textProperty(), converter, format, property, readonly)
 
-inline fun <reified T : Any> TitledPane.bind(property: Property<T>, readonly: Boolean = false, converter: StringConverter<T>? = null, format: Format? = null) =
+inline fun <reified T> TitledPane.bind(property: Property<T>, readonly: Boolean = false, converter: StringConverter<T>? = null, format: Format? = null) =
         bindStringProperty(textProperty(), converter, format, property, readonly)
 
-inline fun <reified T : Any> Text.bind(property: Property<T>, readonly: Boolean = false, converter: StringConverter<T>? = null, format: Format? = null) =
+inline fun <reified T> Text.bind(property: Property<T>, readonly: Boolean = false, converter: StringConverter<T>? = null, format: Format? = null) =
         bindStringProperty(textProperty(), converter, format, property, readonly)
 
-inline fun <reified T : Any> TextInputControl.bind(property: Property<T>, readonly: Boolean = false, converter: StringConverter<T>? = null, format: Format? = null) =
+inline fun <reified T> TextInputControl.bind(property: Property<T>, readonly: Boolean = false, converter: StringConverter<T>? = null, format: Format? = null) =
     bindStringProperty(textProperty(), converter, format, property, readonly)
 
-inline fun <reified T : Any> bindStringProperty(stringProperty: StringProperty, converter: StringConverter<T>?, format: Format?, property: Property<T>, readonly: Boolean) {
+inline fun <reified T> bindStringProperty(stringProperty: StringProperty, converter: StringConverter<T>?, format: Format?, property: Property<T>, readonly: Boolean) {
     if (stringProperty.isBound) stringProperty.unbind()
 
     if (T::class == String::class) {
@@ -80,20 +82,23 @@ inline fun <reified T : Any> bindStringProperty(stringProperty: StringProperty, 
     }
 }
 
-inline fun <reified T : Any> getDefaultConverter(): StringConverter<T>? {
-    val converter: StringConverter<out Any>? = when (T::class.javaPrimitiveType ?: T::class) {
-        Int::class.javaPrimitiveType -> IntegerStringConverter()
-        Long::class.javaPrimitiveType -> LongStringConverter()
-        Double::class.javaPrimitiveType -> DoubleStringConverter()
-        Float::class.javaPrimitiveType -> FloatStringConverter()
-        Date::class -> DateStringConverter()
+inline fun <reified T> getDefaultConverter(): StringConverter<T>? {
+    val converter: StringConverter<out Any>? = when (Class.forName(T::class.jvmName)) {
+
+        Int::class.javaObjectType -> IntegerStringConverter()
+        Long::class.javaObjectType -> LongStringConverter()
+        Double::class.javaObjectType -> DoubleStringConverter()
+        Float::class.javaObjectType -> FloatStringConverter()
+        Date::class.javaObjectType -> DateStringConverter()
+        Boolean::class.javaObjectType -> BooleanStringConverter()
+
         BigDecimal::class -> BigDecimalStringConverter()
         BigInteger::class -> BigIntegerStringConverter()
         Number::class -> NumberStringConverter()
         LocalDate::class -> LocalDateStringConverter()
         LocalTime::class -> LocalTimeStringConverter()
         LocalDateTime::class -> LocalDateTimeStringConverter()
-        Boolean::class.javaPrimitiveType -> BooleanStringConverter() as StringConverter<T>
+
         else -> null
     }
     return if (converter != null) converter as StringConverter<T> else null

--- a/src/test/kotlin/tornadofx/tests/PropertiesTest.kt
+++ b/src/test/kotlin/tornadofx/tests/PropertiesTest.kt
@@ -1,17 +1,18 @@
 package tornadofx.tests
 
+import com.sun.javafx.application.PlatformImpl
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleDoubleProperty
+import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
+import javafx.embed.swing.JFXPanel
+import javafx.scene.control.Label
+import javafx.util.StringConverter
+import javafx.util.converter.IntegerStringConverter
 import org.junit.Assert
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import tornadofx.observable
-import tornadofx.onChange
-import tornadofx.property
-import tornadofx.singleAssign
-import tornadofx.getValue
-import tornadofx.setValue
+import tornadofx.*
 import kotlin.test.assertEquals
 
 class PropertiesTest {
@@ -157,5 +158,32 @@ class PropertiesTest {
         property.onChange { called = true }
         property.value = "Changed"
         assertTrue(called)
+    }
+
+    @Test
+    fun bindNullableProperty() {
+        JFXPanel()  // Initialize javafx toolkit
+
+        val property = SimpleObjectProperty<String?>(null)
+
+        val label = Label().apply { bind(property) }
+
+        property.value = "Changed"
+        Assert.assertEquals("Changed", label.text)
+    }
+
+    @Test
+    fun defaultConverterForKotlinPrimitive() {
+        val converter = getDefaultConverter<Int>()
+        Assert.assertNotNull(converter)
+        Assert.assertTrue(converter is IntegerStringConverter)
+    }
+
+    @Test
+    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+    fun defaultConverterForJavaPrimitive() {
+        val converter = getDefaultConverter<Integer>()
+        Assert.assertNotNull(converter)
+        Assert.assertTrue(converter is IntegerStringConverter)
     }
 }

--- a/src/test/kotlin/tornadofx/tests/PropertiesTest.kt
+++ b/src/test/kotlin/tornadofx/tests/PropertiesTest.kt
@@ -186,4 +186,16 @@ class PropertiesTest {
         Assert.assertNotNull(converter)
         Assert.assertTrue(converter is IntegerStringConverter)
     }
+
+    @Test
+    fun stringConverterWithNullableInt() {
+        JFXPanel()  // Initialize javafx toolkit
+
+        val property = SimpleObjectProperty<Int?>(null)
+
+        val label = Label().apply { bind(property) }
+
+        property.value = null
+        Assert.assertEquals("", label.text)
+    }
 }

--- a/src/test/kotlin/tornadofx/tests/ViewModelTests.kt
+++ b/src/test/kotlin/tornadofx/tests/ViewModelTests.kt
@@ -1,10 +1,14 @@
 package tornadofx.tests
 
+import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
+import javafx.embed.swing.JFXPanel
+import javafx.scene.control.Label
 import javafx.scene.control.TableView
 import javafx.scene.control.TreeItem
 import javafx.scene.control.TreeView
 import javafx.stage.Stage
+import org.junit.Assert
 import org.junit.Assert.*
 import org.junit.Test
 import org.testfx.api.FxToolkit
@@ -104,6 +108,26 @@ open class ViewModelTests {
         }
         treeview.selectionModel.select(treeview.root.children.first())
         assertEquals(model.name.value, "Jay")
+    }
+
+    @Test
+    fun bindNullableProperty() {
+
+        class MyClass {
+            var value by property<Int?>(null)
+            fun valueProperty() = getProperty(MyClass::value)
+        }
+
+        val obj = MyClass()
+
+        val model = object : ViewModel() {
+            val value = bind { obj.valueProperty() }
+        }
+
+        model.value.value = 42
+        assertEquals(obj.value, null)
+        model.commit()
+        assertEquals(obj.value, 42)
     }
 }
 


### PR DESCRIPTION
Hello, 

Today, I've got some difficulties in a particular use-case when using TornadoFX. So, I've decided to propose you a little improvement.

Please consider this model class :

``` kotlin
class MyClass {
    val dateProperty = SimpleObjectProperty<Date?>(null)
    val date: Date? by dateProperty
}
```

Because the type of the property is `Date?` and not `Date`, it was impossible to use the binding as described in the wiki : https://github.com/edvin/tornadofx/wiki/Binding.

By this pull-request, I propose to make possible to write `label().bind(dateProperty)` even if the binded property has a nullable generic type.

Please note this involves a refactoring of the function `getDefaultConverter`, especially in the manner of dealing with java primitive types. I've written two unit tests to ensure there would be no trouble with it.

Thank you for your reading and for your future feedback :-)
