### PR TITLE
Add a KotlinObjectProperty class

### DIFF
--- a/src/main/java/tornadofx/Properties.kt
+++ b/src/main/java/tornadofx/Properties.kt
@@ -25,6 +25,20 @@ class PropertyDelegate<T>(val fxProperty: Property<T>) : ReadWriteProperty<Any, 
 
 }
 
+class KotlinObjectProperty<T>(
+        initialValue: T,
+        bean: Any? = null,
+        name: String = ""
+): SimpleObjectProperty<T>(bean, name, initialValue), ReadWriteProperty<Any, T>{
+
+    override fun get(): T = super.get()
+    override fun set(newValue: T) = super.set(newValue)
+    override fun setValue(v: T) = super.setValue(v)
+
+    override fun getValue(thisRef: Any, property: KProperty<*>) = get()
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: T) = set(value)
+}
+
 fun <T> Any.getProperty(prop: KMutableProperty1<*, T>): ObjectProperty<T> {
     // avoid kotlin-reflect dependency
     val field = javaClass.findFieldByName("${prop.name}\$delegate")
@@ -185,8 +199,8 @@ private class UnsynchronizedSingleAssign<T> : SingleAssign<T> {
     override fun isInitialized() = initialized
 }
 
-operator fun <T> ObservableValue<T>.getValue(thisRef: Any, property: KProperty<*>) = value
-operator fun <T> Property<T?>.setValue(thisRef: Any, property: KProperty<*>, value: T?) {
+operator fun <T : Any> ObservableValue<T>.getValue(thisRef: Any, property: KProperty<*>): T = value
+operator fun <T : Any> Property<T>.setValue(thisRef: Any, property: KProperty<*>, value: T) {
     this.value = value
 }
 

--- a/src/test/kotlin/tornadofx/tests/PropertiesTest.kt
+++ b/src/test/kotlin/tornadofx/tests/PropertiesTest.kt
@@ -12,6 +12,8 @@ import tornadofx.property
 import tornadofx.singleAssign
 import tornadofx.getValue
 import tornadofx.setValue
+import tornadofx.KotlinObjectProperty
+import kotlin.properties.ReadWriteProperty
 import kotlin.test.assertEquals
 
 class PropertiesTest {
@@ -157,5 +159,32 @@ class PropertiesTest {
         property.onChange { called = true }
         property.value = "Changed"
         assertTrue(called)
+    }
+
+    @Test
+    fun kotlinObjectProperty() {
+        val property = KotlinObjectProperty(3)
+
+        Assert.assertTrue(property is ReadWriteProperty<*, Int>)
+        Assert.assertNotNull(property.get())
+
+        // Here the kotlin compiler wouldn't compile : property.set(null)
+
+        property.set(42)
+        Assert.assertNotNull(property.get())
+        Assert.assertEquals(42, property.get())
+    }
+
+    @Test
+    fun kotlinObjectPropertyNullable() {
+        val property = KotlinObjectProperty<Int?>(null)
+        Assert.assertTrue(property is ReadWriteProperty<*, Int?>)
+
+        property.set(null)
+        Assert.assertNull(property.get())
+
+        property.set(42)
+        Assert.assertNotNull(property.get())
+        Assert.assertEquals(42, property.get())
     }
 }


### PR DESCRIPTION
In the MR #174, we discussed, that it would be nice to have a `KotlinObjectProperty` that can handle null value. Here is my implementaiton proposition.

How to use it :
```kotlin
class MyClass {
    val dateProperty = KotlinObjectProperty<Date?>(null)
    val date by dateProperty    // the inferred type of date is Date?
}
```

It's almost like a `SimpleObjectProperty` except, the property type is declared in kotlin, that allow more explicit typing and let the kotlin compiler ensure the absence of [NPE](https://kotlinlang.org/docs/reference/null-safety.html).

For exemple, this code will not compile :
```kotlin
class MyClass {
    val numberProperty = KotlinObjectProperty<Int>(42)
    var number: Int? by numberProperty // The kotlin compiler will raise a type mismatch (Int? is not compatible with Int)
}
```