### PR TITLE
Fix exception of chooseFile with the mode Multi

### DIFF
--- a/src/main/java/tornadofx/Dialogs.kt
+++ b/src/main/java/tornadofx/Dialogs.kt
@@ -47,7 +47,7 @@ fun chooseFile(title: String? = null, filters: Array<FileChooser.ExtensionFilter
             val result = chooser.showOpenDialog(owner)
             if (result == null) emptyList() else listOf(result)
         }
-        Multi -> chooser.showOpenMultipleDialog(owner)
+        Multi -> chooser.showOpenMultipleDialog(owner) ?: emptyList()
         Save -> {
             val result = chooser.showSaveDialog(owner)
             if (result == null) emptyList() else listOf(result)


### PR DESCRIPTION
Hello, 

I encountered a bug when using TornadoFX at work. So I propose a fix for it.

With the function `chooseFile()` in the mode `FileChooserMode.Multi` there can be an exception if the user click on "cancel" in the dialog.

## Exemple :
```kotlin
class MyView : View() {
    override val root = hbox()
}

class MyApp : App(MyView::class) {
    init {
        chooseFile(filters = emptyArray(), mode = FileChooserMode.Multi)
    }
}
```

If in the file chooser dialog if you click "cancel" this exception will be thrown :
```
java.lang.IllegalStateException: chooser.showOpenMultipleDialog(owner) must not be null
	at tornadofx.DialogsKt.chooseFile(Dialogs.kt:50)
	at tornadofx.DialogsKt.chooseFile$default(Dialogs.kt:40)
       ...
```

## Solution
I added `?: emptyList()` at the end of  `chooser.showOpenMultipleDialog(owner)` to ensure an empty list whould be return in the case of a null result.