### PR TITLE
[#184] Added Property<Number> textfield() function

### DIFF
--- a/src/main/java/tornadofx/Controls.kt
+++ b/src/main/java/tornadofx/Controls.kt
@@ -1,7 +1,6 @@
 package tornadofx
 
 import javafx.beans.property.Property
-import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.value.ObservableValue
 import javafx.event.EventTarget
 import javafx.geometry.Orientation

--- a/src/main/java/tornadofx/Controls.kt
+++ b/src/main/java/tornadofx/Controls.kt
@@ -1,6 +1,7 @@
 package tornadofx
 
 import javafx.beans.property.Property
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.value.ObservableValue
 import javafx.event.EventTarget
 import javafx.geometry.Orientation
@@ -78,7 +79,14 @@ fun EventTarget.text(observable: ObservableValue<String>, op: (Text.() -> Unit)?
 }
 
 fun EventTarget.textfield(value: String? = null, op: (TextField.() -> Unit)? = null) = opcr(this, TextField().apply { if (value != null) text = value }, op)
+
 fun EventTarget.textfield(property: Property<String>, op: (TextField.() -> Unit)? = null) = textfield().apply {
+    bind(property)
+    op?.invoke(this)
+}
+
+@JvmName("textfieldNumber")
+fun EventTarget.textfield(property: Property<Number>, op: (TextField.() -> Unit)? = null) = textfield().apply {
     bind(property)
     op?.invoke(this)
 }

--- a/src/test/kotlin/tornadofx/tests/ControlsTest.kt
+++ b/src/test/kotlin/tornadofx/tests/ControlsTest.kt
@@ -1,0 +1,43 @@
+package tornadofx.tests
+
+import javafx.beans.property.SimpleDoubleProperty
+import javafx.beans.property.SimpleIntegerProperty
+import javafx.beans.property.SimpleStringProperty
+import javafx.embed.swing.JFXPanel
+import javafx.scene.layout.VBox
+import javafx.util.converter.NumberStringConverter
+import org.junit.Test
+import tornadofx.View
+import tornadofx.bind
+import tornadofx.textfield
+
+/**
+ * @author carl
+ */
+
+class TestView : View() {
+    override val root = VBox()
+}
+
+class ControlsTest {
+
+    @Test
+    fun testTextfield() {
+
+        JFXPanel()
+
+        val view = TestView()
+
+        view.textfield(SimpleStringProperty("carl"))
+
+        view.textfield(SimpleIntegerProperty(101), NumberStringConverter())
+
+        view.textfield() {
+            bind(SimpleIntegerProperty(102))
+        }
+
+        view.textfield(SimpleIntegerProperty(103))  // w. fix 184
+
+        view.textfield(SimpleDoubleProperty(100.131))  // also fixed 184
+    }
+}


### PR DESCRIPTION
I added a method alongside the Property<String> textfield() method to handle Property<Number> arguments.  This will allow

textfield(SimpleStringProperty("test"))

as well as

textfield(SimpleIntegerProperty(101))
textfield(SimpleDoubleProperty(6.02))

I also put in a unit test "Controls.kt".  It initializes the FX toolkit, so it may be a little slow for the project.