### PR TITLE
overload for di() delegate to support named dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.5.10-SNAPSHOT]
 
+- di delegate overload to support injecting a dependency by name (in addition to type)
 - Fixed scope support. `DefaultScope(MyController::class)` or `MyController::class.scope(DefaultScope)`
 - TableColumn hasClass/addClass/removeClass/toggleClass supports type safe stylesheets
 - Lots of functions that earlier accepted Double now accept Number

--- a/src/main/java/tornadofx/Component.kt
+++ b/src/main/java/tornadofx/Component.kt
@@ -137,10 +137,20 @@ abstract class Component {
         }
     }
 
-    inline fun <reified T : Any> di(): ReadOnlyProperty<Component, T> = object : ReadOnlyProperty<Component, T> {
+    inline fun <reified T : Any> di( name: String? = null ): ReadOnlyProperty<Component, T> = object : ReadOnlyProperty<Component, T> {
         var injected: T? = null
         override fun getValue(thisRef: Component, property: KProperty<*>): T {
-            if (injected == null) injected = FX.dicontainer?.let { it.getInstance(T::class) } ?: throw AssertionError("Injector is not configured, so bean of type ${T::class} can not be resolved")
+            if( FX.dicontainer == null ){
+                throw AssertionError("Injector is not configured, so bean of type ${T::class} cannot be resolved")
+            } else {
+                if (injected == null) injected = FX.dicontainer?.let {
+                    if (name != null) {
+                        it.getInstance(T::class, name)
+                    } else {
+                        it.getInstance(T::class)
+                    }
+                }
+            }
             return injected!!
         }
     }

--- a/src/main/java/tornadofx/FX.kt
+++ b/src/main/java/tornadofx/FX.kt
@@ -337,7 +337,10 @@ fun <T : Component> find(type: KClass<T>, scope: Scope = DefaultScope, vararg pa
 }
 
 interface DIContainer {
-    fun <T : Any> getInstance(type: KClass<T>): T
+    fun <T : Any> getInstance(type: KClass<T> ): T
+    fun <T : Any> getInstance(type: KClass<T>, name: String ): T {
+        throw AssertionError("Injector is not configured, so bean of type $type with name $name can not be resolved")
+    }
 }
 
 /**


### PR DESCRIPTION
I use spring for DI and would like to be able to reference a bean by name (in addition to class).  This change allows me to configure the DiContainer (from java) as:

```
FX.setDicontainer(new DIContainer() {

	@Override
	public <T> T getInstance( KClass<T> type ) {
		return (T)getContext().getBean(  ((KClassImpl<T>) type).getJClass() );
	}

	@Override
	public <T> T getInstance( KClass<T> type, String name ) {
		return (T)getContext().getBean( ((KClassImpl<T>) type).getJClass(), name );
	}

});
```

which allows me to do the following:

```
val myBean: MyBean by di("myBeanName")
```

I added the additional method so as not to be a breaking change (from Java).  As there may not be many people for whom this is an issue, you could also just overload the existing `getInstance` method as well if you think that's a better approach.
