### PR TITLE
Simplified/Enhanced Pojo Binding support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [1.6.1-SNAPSHOT]
 
+- can now bind to a pojo by providing only a single getter ( eg. person.observable( JavaPerson::getId ) )
+  - API break: previously returned a PojoProperty - now returns an ObjectProperty<T>
+  - uses javafx.beans.property.adapter.JavaBeanObjectPropertyBuilder and will now propogate PropertyChangeEvents from the pojo
 - `field` builder supports `orientation` parameter which will cause input container to be a VBox instead of an HBox (https://github.com/edvin/tornadofx/issues/190)
 - UIComponents can now be instantiated manually instead of via inject() and find()
 - Input Control builders now support ObservableValue instead of just Property for automatic binding

--- a/src/main/java/tornadofx/Properties.kt
+++ b/src/main/java/tornadofx/Properties.kt
@@ -3,12 +3,14 @@ package tornadofx
 import javafx.beans.Observable
 import javafx.beans.binding.*
 import javafx.beans.property.*
+import javafx.beans.property.adapter.JavaBeanObjectPropertyBuilder
 import javafx.beans.value.*
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.concurrent.Callable
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.*
+import kotlin.reflect.jvm.javaMethod
 
 fun <T> property(value: T? = null) = PropertyDelegate(SimpleObjectProperty<T>(value))
 fun <T> property(block: () -> Property<T>) = PropertyDelegate(block())
@@ -72,51 +74,25 @@ fun <S, T> observable(owner: S, prop: KProperty1<S, T>): ReadOnlyObjectProperty<
     }
 }
 
-/**
- * Convert an bean instance and a corresponding getter/setter reference into a writable observable.
- *
- * Example: val observableName = observable(myPojo, MyPojo::getName, MyPojo::setName)
- */
-fun <S : Any, T> observable(bean: S, getter: KFunction<T>, setter: KFunction2<S, T, Unit>): PojoProperty<T> {
-    val propName = getter.name.substring(3).let { it.first().toLowerCase() + it.substring(1) }
-
-    return object : PojoProperty<T>(bean, propName) {
-        override fun get() = getter.call(bean)
-        override fun set(newValue: T) {
-            setter.invoke(bean, newValue)
-        }
-    }
-}
-
-@JvmName("pojoObservable")
-fun <S : Any, T> S.observable(getter: KFunction<T>, setter: KFunction2<S, T, Unit>): PojoProperty<T> =
-        observable(this, getter, setter)
-
-open class PojoProperty<T>(bean: Any, propName: String) : SimpleObjectProperty<T>(bean, propName) {
-    fun refresh() {
-        fireValueChangedEvent()
-    }
-}
-
-@Suppress("UNCHECKED_CAST")
-fun <S : Any, T : Any> observable(bean: S, propName: String, propType: KClass<T>): PojoProperty<T> {
-    val suffix = propName.capitalize()
-
-    val getter = bean.javaClass.getDeclaredMethod("get$suffix")
-    val setter = bean.javaClass.getDeclaredMethod("set$suffix", propType.java)
-
-    return object : PojoProperty<T>(bean, propName) {
-        override fun get() = getter.invoke(bean) as T
-        override fun set(newValue: T) {
-            setter.invoke(bean, newValue)
-        }
-    }
-
-}
 
 @JvmName("pojoObservable")
 inline fun <reified T : Any> Any.observable(propName: String) =
-        observable(this, propName, T::class)
+        this.observable( propertyName = propName, propertyType = T::class )
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified S : Any, reified T : Any> S.observable( getter: KFunction<T>? = null, setter: KFunction2<S, T, Unit>? = null, propertyName: String? = null, @Suppress("UNUSED_PARAMETER")propertyType: KClass<T>? = null ): ObjectProperty<T> {
+    if( getter == null && propertyName == null ) throw AssertionError("Either getter or propertyName must be provided")
+    var propName = propertyName
+    if( propName == null && getter != null ){
+        propName = getter.name.substring(3).let { it.first().toLowerCase() + it.substring(1) }
+    }
+    return JavaBeanObjectPropertyBuilder.create().apply{
+        bean( this@observable )
+        this.name( propName )
+        if( getter != null ) this.getter( getter.javaMethod )
+        if( setter != null ) this.setter( setter.javaMethod )
+    } .build() as ObjectProperty<T>
+}
 
 enum class SingleAssignThreadSafetyMode {
     SYNCHRONIZED,

--- a/src/test/kotlin/tornadofx/tests/JavaPerson.java
+++ b/src/test/kotlin/tornadofx/tests/JavaPerson.java
@@ -1,15 +1,26 @@
 package tornadofx.tests;
 
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+
 public class JavaPerson {
+
+    private PropertyChangeSupport pcs;
     private Integer id;
     private String name;
+
+    public JavaPerson(){
+        pcs = new PropertyChangeSupport(this);
+    }
 
     public Integer getId() {
         return id;
     }
 
     public void setId(Integer id) {
+        Integer oldValue = this.id;
         this.id = id;
+        //pcs.firePropertyChange("id",oldValue,id);
     }
 
     public String getName() {
@@ -17,7 +28,9 @@ public class JavaPerson {
     }
 
     public void setName(String name) {
+        String oldValue = this.name;
         this.name = name;
+        pcs.firePropertyChange("name",oldValue,name);
     }
 
     public String toString() {
@@ -26,4 +39,14 @@ public class JavaPerson {
                 ", name='" + name + '\'' +
                 '}';
     }
+
+    public void addPropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.addPropertyChangeListener(listener);
+    }
+
+    public void removePropertyChangeListener(PropertyChangeListener listener) {
+        this.pcs.removePropertyChangeListener(listener);
+    }
+
+
 }

--- a/src/test/kotlin/tornadofx/tests/JavaPerson.java
+++ b/src/test/kotlin/tornadofx/tests/JavaPerson.java
@@ -20,7 +20,7 @@ public class JavaPerson {
     public void setId(Integer id) {
         Integer oldValue = this.id;
         this.id = id;
-        //pcs.firePropertyChange("id",oldValue,id);
+        pcs.firePropertyChange("id",oldValue,id);
     }
 
     public String getName() {

--- a/src/test/kotlin/tornadofx/tests/PropertiesTest.kt
+++ b/src/test/kotlin/tornadofx/tests/PropertiesTest.kt
@@ -155,7 +155,28 @@ class PropertiesTest {
         Assert.assertEquals("Doe", person.name)
 
         person.id = 5
-        idObservable.refresh()
+        Assert.assertEquals(5, idObservable.value)
+    }
+
+    @Test
+    fun pojoWritableObservableGetterOnly() {
+        val person = JavaPerson()
+        person.id = 1
+        person.name = "John"
+
+        val idObservable = person.observable( JavaPerson::getId )
+        val nameObservable = person.observable<String>("name")
+        val idBinding = idObservable.integerBinding{ idObservable.value }
+
+        idObservable.value = 44
+        nameObservable.value = "Doe"
+        Assert.assertEquals(44, idBinding.value )
+        Assert.assertEquals(44, person.id)
+        Assert.assertEquals("Doe", person.name)
+
+        person.id = 5
+        // property change events on the pojo are propogated
+        Assert.assertEquals( 5, idBinding.value )
         Assert.assertEquals(5, idObservable.value)
     }
 


### PR DESCRIPTION
Can now bind to a pojo (that follows java beans conventions) by only specifying a getter.

`myPojo.observable(MyPojo::getName)`

Uses javafx.beans.property.adapter.JavaBeanObjectPropertyBuilder under the covers.  An added benefit to this is that it now listens to propertyChangeEvents on the underlying pojo.

Unfortunately it is an api breaking change in that it returns ObjectProperty<T> and not PojoProperty<T> as before.  The way binding is usually used, this shouldn't generally cause any issues.  I understand if you decide not to implement this for this reason.

In addition, I couldn't figure out any way to make the following method backward compatible so I left it as is.

```
/**
 * Convert an bean instance and a corresponding getter/setter reference into a writable observable.
 *
 * Example: val observableName = observable(myPojo, MyPojo::getName, MyPojo::setName)
 */
fun <S : Any, T> observable(bean: S, getter: KFunction<T>, setter: KFunction2<S, T, Unit>): PojoProperty<T> {
    val propName = getter.name.substring(3).let { it.first().toLowerCase() + it.substring(1) }

    return object : PojoProperty<T>(bean, propName) {
        override fun get() = getter.call(bean)
        override fun set(newValue: T) {
            setter.invoke(bean, newValue)
        }
    }
}
```

Looking forward to your feedback and I'm fine with it if you don't want to implement at this point.

Grant

