### PR TITLE
Feature - Color.derive and Color.ladder

### DIFF
--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -14,8 +14,7 @@ import javafx.scene.effect.DropShadow
 import javafx.scene.effect.Effect
 import javafx.scene.effect.InnerShadow
 import javafx.scene.layout.*
-import javafx.scene.paint.Color
-import javafx.scene.paint.Paint
+import javafx.scene.paint.*
 import javafx.scene.shape.StrokeLineCap
 import javafx.scene.shape.StrokeLineJoin
 import javafx.scene.shape.StrokeType
@@ -1229,6 +1228,24 @@ fun c(red: Int, green: Int, blue: Int, opacity: Double = 1.0): Color = try {
 } catch (e: Exception) {
     Stylesheet.log.warning("Error parsing color c(red=$red, green=$green, blue=$blue, opacity=$opacity)")
     Color.MAGENTA
+}
+
+internal fun Color.withOpacity(newOpacity: Double) = Color(red, green, blue, newOpacity)
+
+fun Color.derive(ratio: Double, opacity: Double = this.opacity) = (if (ratio < 0) interpolate(Color.BLACK, -ratio) else interpolate(Color.WHITE, ratio)).withOpacity(opacity)
+
+fun Color.ladder(vararg stops: Stop): Color {
+    val offset = brightness
+    val nStops = LinearGradient(0.0, 1.0, 0.0, 1.0, false, CycleMethod.NO_CYCLE, *stops).stops
+    return if (offset <= 0.0) {
+        nStops.first().color
+    } else if (offset >= 1.0) {
+        nStops.last().color
+    } else {
+        val left = nStops.last { it.offset <= offset }
+        val right = nStops.first { it.offset >= offset }
+        if (right.offset == left.offset) left.color else left.color.interpolate(right.color, (offset - left.offset) / (right.offset - left.offset))
+    }
 }
 
 fun <T> multi(vararg elements: T) = MultiValue(elements)

--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -1230,9 +1230,7 @@ fun c(red: Int, green: Int, blue: Int, opacity: Double = 1.0): Color = try {
     Color.MAGENTA
 }
 
-internal fun Color.withOpacity(newOpacity: Double) = Color(red, green, blue, newOpacity)
-
-fun Color.derive(ratio: Double, opacity: Double = this.opacity) = (if (ratio < 0) interpolate(Color.BLACK, -ratio) else interpolate(Color.WHITE, ratio)).withOpacity(opacity)
+fun Color.derive(ratio: Double) = if (ratio < 0) interpolate(Color(0.0, 0.0, 0.0, opacity), -ratio)!! else interpolate(Color(1.0, 1.0, 1.0, opacity), ratio)!!
 
 fun Color.ladder(vararg stops: Stop): Color {
     val offset = brightness

--- a/src/test/kotlin/tornadofx/tests/StylesheetTests.kt
+++ b/src/test/kotlin/tornadofx/tests/StylesheetTests.kt
@@ -58,6 +58,14 @@ class StylesheetTests {
     enum class Bool { TRUE, FALSE, FILE_NOT_FOUND }
 
     @Test
+    fun deriveTest() {
+        val color = Color.hsb(0.0, 1.0, 0.5, 0.8)
+        Assert.assertEquals(Color.RED, color.derive(0.5))
+        Assert.assertEquals(Color.RED, color.derive(-0.5))
+        Assert.assertEquals(Color.RED, color.ladder(Stop(0.0, Color.BLACK), Stop(1.0, Color.WHITE), Stop(0.2, Color.RED), Stop(0.2, Color.GREEN), Stop(0.2, Color.BLUE)))
+    }
+
+    @Test
     fun useCustomRenderer() {
         stylesheet {
             label {

--- a/src/test/kotlin/tornadofx/tests/StylesheetTests.kt
+++ b/src/test/kotlin/tornadofx/tests/StylesheetTests.kt
@@ -58,11 +58,25 @@ class StylesheetTests {
     enum class Bool { TRUE, FALSE, FILE_NOT_FOUND }
 
     @Test
-    fun deriveTest() {
+    fun colorLadderTest() {
+        val stops = arrayOf(
+                Stop(0.0, Color.TRANSPARENT),
+                Stop(1.0, Color.WHITE),
+                Stop(0.5, Color.RED),  // Should be left side of 0.2
+                Stop(0.5, Color.GREEN),  // Should be ignored
+                Stop(0.5, Color.BLUE)  // Should be right side of 0.2
+        )
+        Color.hsb(0.0, 1.0, 0.3).ladder(*stops) shouldEqual Color(0.6, 0.0, 0.0, 0.6)
+        Color.hsb(0.0, 1.0, 0.6).ladder(*stops) shouldEqual Color(0.2, 0.2, 1.0, 1.0)
+        Color.hsb(0.0, 1.0, 0.4999).ladder(*stops) shouldEqual Color.RED
+        Color.hsb(0.0, 1.0, 0.5).ladder(*stops) shouldEqual Color.BLUE
+    }
+
+    @Test
+    fun colorDeriveTest() {
         val color = Color.hsb(0.0, 1.0, 0.5, 0.8)
-        Assert.assertEquals(Color.RED, color.derive(0.5))
-        Assert.assertEquals(Color.RED, color.derive(-0.5))
-        Assert.assertEquals(Color.RED, color.ladder(Stop(0.0, Color.BLACK), Stop(1.0, Color.WHITE), Stop(0.2, Color.RED), Stop(0.2, Color.GREEN), Stop(0.2, Color.BLUE)))
+        color.derive(0.5) shouldEqual Color(0.75, 0.5, 0.5, 0.8)
+        color.derive(-0.5) shouldEqual Color(0.25, 0.0, 0.0, 0.8)
     }
 
     @Test
@@ -500,6 +514,7 @@ class StylesheetTests {
 
     private fun stylesheet(op: Stylesheet.() -> Unit) = Stylesheet().apply(op)
     infix fun Stylesheet.shouldEqual(op: () -> String) = Assert.assertEquals(op().strip(), render().strip())
+    infix fun Color.shouldEqual(other: Color) = Assert.assertEquals(other.toString(), toString())
     private fun String.strip() = replace(Regex("\\s+"), " ").trim()
 
     /**


### PR DESCRIPTION
The ladder isn't super efficient as it creates a linear gradient to normalize the stops (`Stops.normalize()` is package private, so it was the easiest way to access it that will be Jigsaw complaint), but I'm not sure if it's a big deal since it's only run once.