### PR TITLE
Fix TableView sort when using SortedFilteredList

### DIFF
--- a/src/main/java/tornadofx/Lib.kt
+++ b/src/main/java/tornadofx/Lib.kt
@@ -71,7 +71,7 @@ class SortedFilteredList<T>(
      * The underlying sortedItems.comparatorProperty` is automatically bound to `tableView.comparatorProperty`.
      */
     fun bindTo(tableView: TableView<T>): SortedFilteredList<T> {
-        tableView.items = this
+        tableView.items = sortedItems
         sortedItems.comparatorProperty().bind(tableView.comparatorProperty())
         return this
     }
@@ -83,7 +83,7 @@ class SortedFilteredList<T>(
      *
      */
     fun bindTo(listView: ListView<T>): SortedFilteredList<T> {
-        listView.items = this
+        listView.items = sortedItems
         return this
     }
 

--- a/src/test/kotlin/tornadofx/testapps/TableViewSortFilterTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/TableViewSortFilterTest.kt
@@ -1,0 +1,44 @@
+package tornadofx.testapps
+
+import javafx.collections.FXCollections
+import javafx.scene.control.TableView
+import javafx.scene.control.TextField
+import tornadofx.*
+import java.time.LocalDate
+
+
+class TableViewSortFilterTestApp : App(TableViewSortFilterTest::class)
+
+class TableViewSortFilterTest : View("Table Sort and Filter") {
+
+	data class Person(val id: Int, var name: String, var birthday: LocalDate) {
+		val age: Int 
+			get() = birthday.until(LocalDate.now()).years
+	}
+
+	private val persons = FXCollections.observableArrayList(
+			Person(1, "Samantha Stuart", LocalDate.of(1981, 12, 4)),
+			Person(2, "Tom Marks", LocalDate.of(2001, 1, 23)),
+			Person(3, "Stuart Gills", LocalDate.of(1989, 5, 23)),
+			Person(3, "Nicole Williams", LocalDate.of(1998, 8, 11))
+	)
+
+	var table: TableView<Person> by singleAssign()
+	var textfield: TextField by singleAssign()
+
+	override val root = vbox {
+		textfield = textfield()
+
+		table = tableview {
+			column("ID", Person::id)
+			column("Name", Person::name)
+			column("Birthday", Person::birthday)
+			column("Age", Person::age)
+		}
+	}
+
+	init {
+		SortedFilteredList(persons).bindTo(table)
+				.filterWhen(textfield.textProperty(), { query, item -> item.name.contains(query, true) })
+	}
+}


### PR DESCRIPTION
When using SortedFilteredList.bindTo() to bind it to a TableView the header becomes "unclickable" and therefor unsortable. Setting tableView.items to the underlying "sortedItems" instead of "this" fix the problem.