### PR TITLE
added resizeIcon boolean to trayicon functions

### DIFF
--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -109,19 +109,19 @@ open class App(primaryView: KClass<out UIComponent>? = null, vararg stylesheet: 
         override val root = Pane()
     }
 
-    fun trayicon(image: BufferedImage, tooltip: String?, implicitExit: Boolean = false, resizeIcon: Boolean = false, op: TrayIcon.() -> Unit){
+    fun trayicon(image: BufferedImage, tooltip: String?, implicitExit: Boolean = false, autoSize: Boolean = false, op: TrayIcon.() -> Unit){
         Platform.setImplicitExit(implicitExit)
         SwingUtilities.invokeLater {
             Toolkit.getDefaultToolkit()
             val trayIcon = TrayIcon(image, tooltip)
-            trayIcon.isImageAutoSize=resizeIcon
+            trayIcon.isImageAutoSize= autoSize
             op(trayIcon)
             SystemTray.getSystemTray().add(trayIcon)
             trayIcons.add(trayIcon)
         }
     }
-    fun trayicon(icon: InputStream, tooltip: String? = null, implicitExit: Boolean = false, resizeIcon: Boolean = false,  op: TrayIcon.() -> Unit) {
-        trayicon(ImageIO.read(icon), tooltip, implicitExit,resizeIcon, op)
+    fun trayicon(icon: InputStream, tooltip: String? = null, implicitExit: Boolean = false, autoSize: Boolean = false, op: TrayIcon.() -> Unit) {
+        trayicon(ImageIO.read(icon), tooltip, implicitExit, autoSize, op)
     }
 
     fun TrayIcon.menu(label: String, op: PopupMenu.() -> Unit) {

--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -109,18 +109,19 @@ open class App(primaryView: KClass<out UIComponent>? = null, vararg stylesheet: 
         override val root = Pane()
     }
 
-    fun trayicon(image: BufferedImage, tooltip: String?, implicitExit: Boolean = false, op: TrayIcon.() -> Unit){
+    fun trayicon(image: BufferedImage, tooltip: String?, implicitExit: Boolean = false, resizeIcon: Boolean = false, op: TrayIcon.() -> Unit){
         Platform.setImplicitExit(implicitExit)
         SwingUtilities.invokeLater {
             Toolkit.getDefaultToolkit()
             val trayIcon = TrayIcon(image, tooltip)
+            trayIcon.isImageAutoSize=resizeIcon
             op(trayIcon)
             SystemTray.getSystemTray().add(trayIcon)
             trayIcons.add(trayIcon)
         }
     }
-    fun trayicon(icon: InputStream, tooltip: String? = null, implicitExit: Boolean = false, op: TrayIcon.() -> Unit) {
-        trayicon(ImageIO.read(icon), tooltip, implicitExit, op)
+    fun trayicon(icon: InputStream, tooltip: String? = null, implicitExit: Boolean = false, resizeIcon: Boolean = false,  op: TrayIcon.() -> Unit) {
+        trayicon(ImageIO.read(icon), tooltip, implicitExit,resizeIcon, op)
     }
 
     fun TrayIcon.menu(label: String, op: PopupMenu.() -> Unit) {


### PR DESCRIPTION
TrayIcon has a setting to automatically resize images that are used as the icon in the tray. This switch turns it on or off. By default it is off