### PR TITLE
Small fix for CSS font size

### DIFF
--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -483,7 +483,7 @@ open class PropertyHolder {
             is CssBox<*> -> "${toCss(value.top)} ${toCss(value.right)} ${toCss(value.bottom)} ${toCss(value.left)}"
             is FontWeight -> "${value.weight}"  // Needs to come before `is Enum<*>`
             is Enum<*> -> value.toString().toLowerCase().replace("_", "-")
-            is Font -> "${if (value.style == "Regular") "normal" else value.style} ${value.size}pt ${toCss(value.family)}"
+            is Font -> "${if (value.style == "Regular") "normal" else value.style} ${value.size}px ${toCss(value.family)}"
             is Cursor -> if (value is ImageCursor) {
                 value.image.javaClass.getDeclaredField("url").let {
                     it.isAccessible = true


### PR DESCRIPTION
Apparently font object sizes are in pixels and not points, despite what the docs would have you believe.