### PR TITLE
Add shortcuts for GridPane.columnConstraints from children.

### DIFF
--- a/src/main/java/tornadofx/Layouts.kt
+++ b/src/main/java/tornadofx/Layouts.kt
@@ -9,6 +9,7 @@ import javafx.scene.Node
 import javafx.scene.canvas.Canvas
 import javafx.scene.control.*
 import javafx.scene.layout.*
+import javafx.scene.Parent
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction1
 

--- a/src/main/java/tornadofx/Layouts.kt
+++ b/src/main/java/tornadofx/Layouts.kt
@@ -38,7 +38,7 @@ fun GridPane.constraintsForColumn(columnIndex: Int): ColumnConstraints {
     return constraints[columnIndex]
 }
 
-val Parent.columnConstraints: ColumnConstraints? get() {
+val Parent.gridpaneColumnConstraints: ColumnConstraints? get() {
     var cursor = this
     var next = parent
     while (next != null) {
@@ -61,7 +61,7 @@ val Parent.columnConstraints: ColumnConstraints? get() {
     return null
 }
 
-fun Parent.columnConstraints(op: ColumnConstraints.() -> Unit) = columnConstraints?.apply { op() }
+fun Parent.gridpaneColumnConstraints(op: ColumnConstraints.() -> Unit) = gridpaneColumnConstraints?.apply { op() }
 
 fun ToolBar.spacer(prio: Priority = Priority.ALWAYS, op: (Pane.() -> Unit)? = null): Pane {
     val pane = Pane().apply {

--- a/src/main/java/tornadofx/Layouts.kt
+++ b/src/main/java/tornadofx/Layouts.kt
@@ -14,14 +14,14 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KFunction1
 
 private val GridPaneRowIdKey = "TornadoFX.GridPaneRowId"
-private val GridPanelParentObjectKey = "TornadoFX.GridPanelParentObject"
+private val GridPaneParentObjectKey = "TornadoFX.GridPaneParentObject"
 
 fun GridPane.row(title: String? = null, op: (Pane.() -> Unit)? = null) {
     properties[GridPaneRowIdKey] = if (properties.containsKey(GridPaneRowIdKey)) properties[GridPaneRowIdKey] as Int + 1 else 0
 
     // Allow the caller to add children to a fake pane
     val fake = Pane()
-    fake.properties[GridPanelParentObjectKey] = this
+    fake.properties[GridPaneParentObjectKey] = this
     if (title != null)
         fake.children.add(Label(title))
 
@@ -45,7 +45,7 @@ val Parent.columnConstraints: ColumnConstraints? get() {
         val gridReference = if (next is GridPane)
             next to GridPane.getColumnIndex(cursor)?.let { it }
         else if (next.parent == null) // perhaps we're still in the row builder
-            (next.properties[GridPanelParentObjectKey] as? GridPane)?.let {
+            (next.properties[GridPaneParentObjectKey] as? GridPane)?.let {
                 it to next.getChildList()?.indexOf(cursor)
             }
         else null


### PR DESCRIPTION
JavaFX makes using ColumnConstraints inside a GridPane moderately annoying. This PR adds a columnConstraints extension method to TornadoFX's declarative DSL, and a `constraintsForColumn` extension method on `GridPane` itself.

A corresponding update to the examples in the guide can be found [here](https://github.com/drmoose/tornadofx-guide/commit/16e70067278ff0c3cbcb132d23ceca66061985a1)