### PR TITLE
Unified the `action` statement in the testapps 

### DIFF
--- a/src/test/kotlin/tornadofx/testapps/BuilderWindowTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/BuilderWindowTest.kt
@@ -10,7 +10,7 @@ import tornadofx.*
 class BuilderWindowTestApp : App(DangerButtonView::class)
 
 class DangerButtonView : View("Do not click the button!") {
-    override val root = stackpane  {
+    override val root = stackpane {
         setPrefSize(400.0, 150.0)
         hbox {
             button("Don't click me") {
@@ -35,40 +35,29 @@ class DangerButtonView : View("Do not click the button!") {
                             }
 
                             hbox(10) {
-                                button("Tell them you clicked") {
-                                    action {
-                                        this@DangerButtonView.title = "It's not dangerous to click the button :)"
-                                        close()
-                                    }
+                                button("Tell them you clicked").action {
+                                    this@DangerButtonView.title = "It's not dangerous to click the button :)"
+                                    close()
                                 }
-                                button("Close app") {
-                                    action {
-                                        Platform.exit()
-                                    }
+                                button("Close app").action {
+                                    Platform.exit()
                                 }
-                                button("Cancel") {
-                                    action {
-                                        close()
-                                    }
+                                button("Cancel").action {
+                                    close()
                                 }
                             }
                         }
                     }
                 }
             }
-            button("the same in internalWindow") {
-                action {
-                    openInternalBuilderWindow("Internal window", modal = true, overlayPaint = Color.DARKRED) {
-                        vbox(20) {
-                            label("opened in an internalwindow")
-                            button("close") {
-                                action { close() }
-                            }
-                        }
+            button("the same in internalWindow").action {
+                openInternalBuilderWindow("Internal window", modal = true, overlayPaint = Color.DARKRED) {
+                    vbox(20) {
+                        label("opened in an internalwindow")
+                        button("close").action { close() }
                     }
                 }
             }
         }
     }
-
 }

--- a/src/test/kotlin/tornadofx/testapps/DrawerTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/DrawerTest.kt
@@ -14,10 +14,8 @@ class DrawerTestApp : App(DrawerWorkspace::class) {
 class JustAView : View("Just A View") {
     override val root = vbox {
         label("I'm just a view - I do nothing")
-        button("Load another View") {
-            action {
-                workspace.dock<TestDrawerContributor>()
-            }
+        button("Load another View").action {
+            workspace.dock<TestDrawerContributor>()
         }
     }
 }
@@ -26,10 +24,8 @@ class TestDrawerContributor : View("Test View with dynamic drawer item") {
     override val root = stackpane {
         vbox {
             label("I add something to the drawer when I'm docked")
-            button("Close") {
-                action {
-                    close()
-                }
+            button("Close").action {
+                close()
             }
         }
     }
@@ -51,10 +47,8 @@ class DrawerWorkspace : Workspace("Drawer Workspace", Workspace.NavigationMode.S
     init {
         menubar {
             menu("Options") {
-                checkmenuitem("Toggle Navigation Mode") {
-                    action {
-                        navigationMode = if (navigationMode == NavigationMode.Stack) NavigationMode.Tabs else NavigationMode.Stack
-                    }
+                checkmenuitem("Toggle Navigation Mode").action {
+                    navigationMode = if (navigationMode == NavigationMode.Stack) NavigationMode.Tabs else NavigationMode.Stack
                 }
             }
         }

--- a/src/test/kotlin/tornadofx/testapps/EventBusTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/EventBusTest.kt
@@ -25,10 +25,8 @@ class EventBusTestView : View("Data Event Table") {
                 requestFocus()
             }
         }
-        button("Load data") {
-            action {
-                fire(GiveMeData)
-            }
+        button("Load data").action {
+            fire(GiveMeData)
         }
     }
 }

--- a/src/test/kotlin/tornadofx/testapps/InternalWindowTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/InternalWindowTest.kt
@@ -8,10 +8,8 @@ class InternalWindowTestApp : App(InternalWindowTest::class)
 class InternalWindowTest : View("Internal Window") {
     override val root = stackpane {
         setPrefSize(600.0, 400.0)
-        button("Open editor") {
-            action {
-                openInternalWindow(Editor::class, modal = false, icon = FX.icon)
-            }
+        button("Open editor").action {
+            openInternalWindow(Editor::class, modal = false, icon = FX.icon)
         }
 
     }

--- a/src/test/kotlin/tornadofx/testapps/ReloadStylesInModal.kt
+++ b/src/test/kotlin/tornadofx/testapps/ReloadStylesInModal.kt
@@ -9,10 +9,8 @@ class ReloadStylesInModal : App(MainView::class, Styles::class) {
 
     class MainView : View() {
         override val root = hbox {
-            button("Open") {
-                action {
-                    find(MyModal::class).openModal()
-                }
+            button("Open").action {
+                find(MyModal::class).openModal()
             }
         }
     }
@@ -20,10 +18,8 @@ class ReloadStylesInModal : App(MainView::class, Styles::class) {
     class MyModal : Fragment() {
         override val root = vbox {
             label("My label")
-            button("Close") {
-                action {
-                    close()
-                }
+            button("Close").action {
+                close()
             }
         }
     }

--- a/src/test/kotlin/tornadofx/testapps/TodoTestApp.kt
+++ b/src/test/kotlin/tornadofx/testapps/TodoTestApp.kt
@@ -26,10 +26,8 @@ class TodoList : View("Todo List") {
 
     override fun onDock() {
         with(workspace) {
-            button("Print todos") {
-                action {
+            button("Print todos").action {
                     println(todos.joinToString("\n"))
-                }
             }
         }
     }


### PR DESCRIPTION
* This pull request is based on discussion on merge #288 
 * If a button or another control has `action { }` as it's only statement
   we should use `button().action { } directly.