### PR TITLE
Config helper rework

### DIFF
--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -12,6 +12,8 @@ import java.awt.event.MouseEvent
 import java.awt.event.MouseEvent.BUTTON1
 import java.awt.image.BufferedImage
 import java.io.InputStream
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.*
 import javax.imageio.ImageIO
 import javax.swing.SwingUtilities
@@ -25,6 +27,32 @@ open class App(primaryView: KClass<out UIComponent>? = null, vararg stylesheet: 
     private val trayIcons = ArrayList<TrayIcon>()
     val resources: ResourceLookup by lazy {
         ResourceLookup(this)
+    }
+
+    //-- Global Config @see Settings.kt
+    open val configBasePath: Path = Paths.get("conf")
+
+    /**
+     * The configPath can be overridden to change the default storage location of the global config file.
+     * If [configPath] is relative, the config file will be stored under App.configBasePath.resolve(configPath)
+     */
+    open val configPath: Path? = null
+
+    private val _configPath = lazy {
+        val path: Path
+        if (configPath == null)
+        // We do this to stay consistent with the old api since the App.configBasePath defaults to Paths.get("conf")
+            path = configBasePath
+        else if (!configPath!!.isAbsolute)
+            path = configBasePath.resolve(configPath)
+        else path = configPath!!
+        path
+    }
+
+    val config: Config by lazy {
+        val conf = Config(javaClass.name, _configPath.value)
+        conf.load()
+        conf
     }
 
     fun <T : FXEvent> fire(event: T) {

--- a/src/main/java/tornadofx/Config.kt
+++ b/src/main/java/tornadofx/Config.kt
@@ -1,0 +1,173 @@
+package tornadofx
+
+import java.io.StringReader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.*
+import javax.json.Json
+import javax.json.JsonArray
+import javax.json.JsonObject
+
+/**
+ * This File contains all config releated classes and functions for tornadofx.
+ *
+ * @author nimakro
+ */
+
+/**
+ * Defines the context in which the settings should be saved.
+ */
+enum class Context {
+    /**
+     * In this context all settings will be stored for a specific component.
+     */
+    COMPONENT,
+
+    /**
+     * This context stores all settings in a global space, which can be accessed from all components.
+     */
+    GLOBAL
+}
+
+/**
+ * Defines a configuration object, which allows to save and restore key value pairs.
+ * @param configTarget The fully qualified path to the storage loaction of the config file.
+ * @param fileName The filename without a file extension.
+ */
+class Config(fileName: String, configTarget: Path): Properties() {
+
+    private val path = lazy {
+        if (!Files.exists(configTarget))
+            Files.createDirectories(configTarget)
+        configTarget.resolve(fileName + ".properties")
+    }
+
+    /**
+     * Stores for the given key the associated value in the config.
+     * If the config contains already the given key with a value, the value
+     * will be overriden.
+     */
+    fun set(pair: Pair<String, Any>) = set(pair.first, pair.second.toString());
+
+    /*
+     * Tries to read the String associated with the given key.
+     * If no matching key could be found <b>null</b> will be returned.
+     *
+     * To use a default value, you can use orElse.
+     * @sample string("title").orElse("New Title")
+     */
+    fun string(key: String): String? = getProperty(key)
+
+    /*
+     * Tries to read the boolean associated with the given key.
+     * If no matching key could be found <b>null</b> will be returned.
+     *
+     * To use a default value, you can use orElse.
+     * @sample boolean("showTitle).orElse(false)
+     */
+    fun boolean(key: String): Boolean? = getProperty(key)?.toBoolean()
+
+    /*
+     * Tries to read the long associated with the given key.
+     * If no matching key could be found <b>null</b> will be returned.
+     *
+     * To use a default value, you can use oreElse.
+     * @sample long("items").orElse(0)
+     */
+    fun long(key: String): Long? = getProperty(key)?.toLong()
+
+    /*
+     * Tries to read the double associated with the given key.
+     * If no matching key could be found <b>null</b> will be returned.
+     *
+     * To use a default value, you can use orElse.
+     * @sample string("title").orElse("New Title")
+     */
+    fun double(key: String): Double? = getProperty(key)?.toDouble()
+
+    /*
+     * Tries to read the JsonObject associated with the given key.
+     * If no matching key could be found <b>null</b> will be returned.
+     *
+     * To use a default value, you can use orElse.
+     * @sample jsonObject("user.info").orElse(otherJsonObject)
+     */
+    fun jsonObject(key: String): JsonObject? = getProperty(key)?.let { Json.createReader(StringReader(it)).readObject() }
+
+    /*
+     * Tries to read the JsonArray associated with the given key.
+     * If no matching key could be found <b>null</b> will be returned.
+     *
+     * To use a default value, you can use orElse.
+     * @sample jsonArray("user.info").orElse(otherJsonArray)
+     */
+    fun jsonArray(key: String): JsonArray? = getProperty(key)?.let { Json.createReader(StringReader(it)).readArray() }
+
+    /**
+     * Saves the given config object.
+     * @param description A description of the config-file.
+     */
+
+    fun save(description: String = "") = Files.newOutputStream(path.value).use {output -> store(output, description)}
+
+    /**
+     * Loads the given config object.
+     * If no config file can be found, this function is a no op.
+     */
+    fun load() {
+        if (Files.exists(path.value))
+            Files.newInputStream(path.value).use { load(it) }
+    }
+}
+
+//-- Helper Functions
+
+/**
+ * Load the config file if it exists and do something with it.
+ */
+fun Component.config(context: Context = Context.COMPONENT, op: Config.() -> Unit) {
+    if (context == Context.COMPONENT)
+        op(config)
+    else if (context == Context.GLOBAL)
+        op((FX.getApplication(scope)!! as App).config)
+    else throw IllegalStateException("State: $context not known!")
+}
+
+/**
+ * Loads the system config file if it exists and do something with it.
+ */
+fun App.config(op: Config.() -> Unit) {
+    op(config)
+}
+
+//-- Default value helper
+/**
+ * Returns this Boolean if not null, otherwise return [other].
+ */
+infix fun Boolean?.orElse(other: Boolean): Boolean = orElse(other)
+
+/**
+ * Returns this String if not null, otherwise return [other].
+ */
+infix fun String?.orElse(other: String): String = if (this != null) this else other
+
+/**
+ * Returns this Double if not null, otherwise return [other].
+ */
+infix fun Double?.orElse(other: Double): Double = if (this != null) this else other
+
+/**
+ * Returns this Long if not null, otherwise return [other].
+ */
+infix fun Long?.orElse(other: Long): Long = if (this != null) this else other
+
+/**
+ * Returns this JsonObject if not null, otherwise return [other].
+ */
+infix fun JsonObject?.orElse(other: JsonObject): JsonObject = if (this != null) this else other
+
+/**
+ * Returns this JsonObject if not null, otherwise return [other].
+ */
+infix fun JsonArray?.orElse(other: JsonArray): JsonArray = if (this != null) this else other
+

--- a/src/test/kotlin/tornadofx/tests/ConfigTest.kt
+++ b/src/test/kotlin/tornadofx/tests/ConfigTest.kt
@@ -1,0 +1,151 @@
+package tornadofx.tests
+
+import javafx.application.Application
+import javafx.stage.Stage
+import org.hamcrest.CoreMatchers.`is`
+import org.junit.Assert
+import org.junit.Assert.assertThat
+import org.junit.Rule
+import org.junit.Test
+import tornadofx.*
+import org.junit.rules.TemporaryFolder
+import org.testfx.api.FxToolkit
+import java.util.function.Supplier
+
+
+/**
+ * Tests for the Config-Api
+ *
+ * @author nimakro
+ */
+class ConfigTest {
+
+    @Rule @JvmField
+    val testFolder = TemporaryFolder()
+
+    class TestApp(testFolder: TemporaryFolder): App(TestView::class) {
+        // This is the default location we just override it to use the tempFolder provided by junit.
+        override val configBasePath = testFolder.newFolder("conf").toPath()
+    }
+
+    class GlobalConfigApp(testFolder: TemporaryFolder): App(TestView::class) {
+        // This is the default location we just override it to use the tempFolder provided by junit.
+        override val configBasePath = testFolder.newFolder("conf").toPath()
+
+        init {
+            // Using the default context and default configPath which is configBasePath
+            config {
+                set("username" to "user")
+                set("password" to "pwd")
+                save()
+            }
+
+            config {
+                assertThat(string("username"), `is`("user"))
+                assertThat(string("password"), `is`("pwd"))
+
+                // Test default
+                assertThat(long("x").orElse(40L), `is`(40L))
+            }
+        }
+    }
+
+    @Test
+    fun testLocalConfigComponent() {
+        val app = TestApp(testFolder)
+        FxToolkit.registerPrimaryStage()
+        FxToolkit.setupApplication{  -> app }
+
+        object : Component() {
+            init {
+               // Using the default context and default configPath which is configBasePath
+               config {
+                   set("username" to "user")
+                   set("password" to "pwd")
+                   save()
+               }
+
+               config {
+                    assertThat(string("username"), `is`("user"))
+                    assertThat(string("password"), `is`("pwd"))
+
+                    // Test default
+                    assertThat(long("x").orElse(40L), `is`(40L))
+               }
+            }
+        }
+    }
+
+    @Test
+    fun testGlobalConfigInComponent() {
+        val app = TestApp(testFolder)
+        FxToolkit.registerPrimaryStage()
+        FxToolkit.setupApplication{  -> app }
+
+        object : Controller() {
+            init {
+                // Using the default context and default configPath which is configBasePath
+                config(Context.GLOBAL) {
+                    set("username" to "user")
+                    set("password" to "pwd")
+                    save()
+                }
+            }
+        }
+
+        object: Controller() {
+            init {
+                config(Context.GLOBAL) {
+                    assertThat(string("username"), `is`("user"))
+                    assertThat(string("password"), `is`("pwd"))
+
+                    // Test default
+                    assertThat(long("x").orElse(40L), `is`(40L))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testGlobalConfigInApp() {
+        FxToolkit.registerPrimaryStage()
+        FxToolkit.setupApplication{ -> GlobalConfigApp(testFolder)}
+    }
+
+    @Test
+    fun testGlobalConfigInAppAndComponent() {
+        val path = testFolder.newFolder("conf").toPath()
+        FxToolkit.registerPrimaryStage()
+        val app = Supplier<Application> { ->
+                object : App(TestView::class) {
+                    // This is the default location we just override it to use the tempFolder provided by junit.
+                    override val configBasePath = path
+
+                    init {
+                        // Using the default context and default configPath which is configBasePath
+                        config {
+                            set("username" to "user")
+                            set("password" to "pwd")
+                            save()
+                        }
+                    }
+
+                }
+        }
+        FxToolkit.setupApplication(app)
+        FxToolkit.cleanupApplication(app.get())
+        FxToolkit.setupApplication(app)
+
+        object: Controller() {
+            init {
+                config(Context.GLOBAL) {
+                    assertThat(string("username"), `is`("user"))
+                    assertThat(string("password"), `is`("pwd"))
+
+                    // Test default
+                    assertThat(long("x").orElse(40L), `is`(40L))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is my current idea for the config helper. I didn't add the changes to the changelog yet since I am not sure if you accept this implementation. If you do let me know and I will add the information to the changelog. If this will get merged I will also change the guide.

The old implementation allowed to store null values, which the new functions do not allow. Except for the ones from Properties them selfs.
If a read function can't find a given key it will return null. I also introduced 
a `orElse` function to work nicely with nulls which can be called like so: ` string(key).orElse(default)` or you do `string(key) ?: default`

The implementation now allows storing `GLOBAL` and `COMPONENT` configs.
```kotlin
class MyController() : Controller() {
    // You can override the directory per component if you like
    // If the configPath is relative it will be placed as a subfolder 
    // of the configBasePath defined in App. 
    // The Default is null, which means the basePath is used 
    // (I did that to be compatible with the old implementation.
    override val configPath = Paths.get("custom-dir")

    init {
        config {
            set("username" to "user")
        }
        config(GLOBAL) {
            // I added orElse to work with defaults.
            val port = string("port").orElse(7777)
        }
    }
}

class MyController2() : Controller() {
    init {
        config(GLOBAL) {
            val port = string("port").orElse(7777)
        }
    }
}


class Application : App() {
    // The default is Paths.get("conf") to be consitent with the old implementation.
    override val configBasePath = Paths.get("custom-dir")
    // The defualt is null, that means it ill be stored in configBasePath
    override val configPath = Paths.get("custom-dir")

    init {
        // Saving to the global space
        config {
            set("title" to "title")
        }
    }
}
```