### PR TITLE
Added lazyContextmenu to create context menus on demand.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Android SDK compatibilty (See https://github.com/edvin/tornadofx-android-compat)
 - JsonStructure.save(path) actually saves (https://github.com/edvin/tornadofx/pull/300)
 - Added `baseColor` CSS property
+- `lazyContextmenu` to add context menus that instantiate when the menu actually opens.
 
 ## [1.7.2] - 2017-04-14
 

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -200,6 +200,7 @@ fun EventTarget.contextmenu(op: (ContextMenu.() -> Unit)? = null): EventTarget {
     } else if (this is Node) {
         this.setOnContextMenuRequested { event ->
             menu.show(this@contextmenu, event.screenX, event.screenY)
+            event.consume()
         }
     }
     return this
@@ -214,6 +215,7 @@ fun EventTarget.lazyContextmenu(op: (ContextMenu.() -> Unit)? = null): EventTarg
             val menu = ContextMenu()
             op?.invoke(menu)
             menu.show(this, event.screenX, event.screenY)
+            event.consume()
         }
     }
     return this

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -204,3 +204,17 @@ fun EventTarget.contextmenu(op: (ContextMenu.() -> Unit)? = null): EventTarget {
     }
     return this
 }
+
+/**
+ * Add a context menu to the target which will be created on demand.
+ */
+fun EventTarget.lazyContextmenu(op: (ContextMenu.() -> Unit)? = null): EventTarget {
+    if (this is Node) {
+        this.setOnContextMenuRequested { event ->
+            val menu = ContextMenu()
+            op?.invoke(menu)
+            menu.show(this, event.screenX, event.screenY)
+        }
+    }
+    return this
+}

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -210,11 +210,15 @@ fun EventTarget.contextmenu(op: (ContextMenu.() -> Unit)? = null): EventTarget {
  * Add a context menu to the target which will be created on demand.
  */
 fun EventTarget.lazyContextmenu(op: (ContextMenu.() -> Unit)? = null): EventTarget {
+    var currentMenu: ContextMenu? = null
     if (this is Node) {
         this.setOnContextMenuRequested { event ->
-            val menu = ContextMenu()
-            op?.invoke(menu)
-            menu.show(this, event.screenX, event.screenY)
+            currentMenu?.hide()
+
+            currentMenu = ContextMenu()
+            currentMenu!!.setOnCloseRequest { currentMenu = null }
+            op?.invoke(currentMenu!!)
+            currentMenu!!.show(this, event.screenX, event.screenY)
             event.consume()
         }
     }


### PR DESCRIPTION
The current `contextmenu` function creates the menu immediately but I sometime need them to be created on demand (many items with menus or children change depending on application state) so I added this functionality.

Could also be done with a lazy flag on the existing `contextmenu` function but I think this keeps the functions a bit cleaner and has the same name format as `TreeView<T>.lazyPopulate`.