### PR TITLE
Brought some order to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,22 @@
 
 ## [1.7.3-SNAPSHOT]
 
-- Improved Java interop
+### Additions
 - ScrollPane.edgeToEdge boolean var to control the "edge-to-edge" style class (https://github.com/edvin/tornadofx/issues/302)
-- Fixed ViewModel validation bug for ComboBox, ChoiceBox and Spinner
-- Removed faulty choicebox builder and replaced it with one similar to the combobox builder
-- Autocomplete ComboBox listview matches width of ComboBox by default
-- `authInterceptor` was deprecated in favor of better named `requestInterceptor`
 - Android SDK compatibilty (See https://github.com/edvin/tornadofx-android-compat)
-- JsonStructure.save(path) actually saves (https://github.com/edvin/tornadofx/pull/300)
 - Added `baseColor` CSS property
 - `lazyContextmenu` to add context menus that instantiate when the menu actually opens.
+
+### Changes
+- Improved Java interop
+- Removed faulty choicebox builder and replaced it with one similar to the combobox builder
+- `authInterceptor` was deprecated in favor of better named `requestInterceptor`
+
+### Fixes
+- Fixed ViewModel validation bug for ComboBox, ChoiceBox and Spinner
+- Autocomplete ComboBox listview matches width of ComboBox by default
+- JsonStructure.save(path) actually saves (https://github.com/edvin/tornadofx/pull/300)
+
 
 ## [1.7.2] - 2017-04-14
 


### PR DESCRIPTION
I suggest we categorize the changes in the changelog a bit to make it easier to spot changes and new features that might necessitate changes in the applications using tornadofx. (The changelog for 1.7.1 was crazy long - which is great - but also hard to parse ;) )

It might also be interesting to highlight completely new features such as the wizard or the autocomplete.