### PR TITLE
Changed PropertyHolder.fontFamily to MultiValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - added option to increment and decrement spinners by scrolling (https://github.com/edvin/tornadofx/pull/425)
 - onUndock is now called for the View currently embedded as the scene root of a Window when it closes (https://github.com/edvin/tornadofx/issues/427)
 - Launch<AppClass> helper for nicer main functions (https://github.com/edvin/tornadofx/pull/431)
+- Changed PropertyHolder.fontFamily from String to MultiValue<String>
 
 ### Additions
 

--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -560,7 +560,7 @@ open class PropertyHolder {
 
     // Font
     var font: Font by cssprop("-fx-font")
-    var fontFamily: String by cssprop("-fx-font-family")
+    var fontFamily: MultiValue<String> by cssprop("-fx-font-family")
     var fontSize: Dimension<Dimension.LinearUnits> by cssprop("-fx-font-size")
     var fontStyle: FontPosture by cssprop("-fx-font-style")
     var fontWeight: FontWeight by cssprop("-fx-font-weight")

--- a/src/test/kotlin/tornadofx/testapps/DrawerTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/DrawerTest.kt
@@ -76,7 +76,7 @@ Process finished with exit code 0
                     style {
                         backgroundColor += Color.BLACK
                         textFill = Color.LIGHTGREY
-                        fontFamily = "Consolas"
+                        fontFamily += "Consolas"
                     }
                 }
             }


### PR DESCRIPTION
Used for fallback fonts

Kotlin:
````kotlin
label {
    fontFamily = multi("Helvetica", "Arial", "sans-serif")
}
````

CSS:
````css
.label {
    -fx-font-family: "Helvetica", "Arial", "sans-serif";
}
````