### PR TITLE
Style the accent color with type-safe CSS, closes #448

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - FX.addChildInterceptor that can veto or custom add builder children to their parent. Useful for MigPane for example.
 - Tab.select() for easier selection of tab without having to access tabPane.selectionModel
 - TabPane.contains(UIComponent) and Iterable<Node>.contains(UIComponent)
+- Override -fx-accent with type-safe CSS property accentColor
 
 ## [1.7.10]
 

--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -555,6 +555,7 @@ open class PropertyHolder {
 
     // Root
     var baseColor: Color by cssprop("-fx-base")
+    var accentColor: Color by cssprop("-fx-accent")
     var focusColor: Paint by cssprop("-fx-focus-color")
     var faintFocusColor: Paint by cssprop("-fx-faint-focus-color")
 


### PR DESCRIPTION
Override -fx-accent with type-safe CSS property accentColor