### PR TITLE
switch argument names of box function

### DIFF
--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -1271,7 +1271,7 @@ fun <T : Node> T.setId(cssId: CssRule): T {
 // Containers
 
 fun <T> box(all: T) = CssBox(all, all, all, all)
-fun <T> box(vertical: T, horizontal: T) = CssBox(vertical, horizontal, vertical, horizontal)
+fun <T> box(horizontal: T, vertical: T) = CssBox(horizontal, vertical, horizontal, vertical)
 fun <T> box(top: T, right: T, bottom: T, left: T) = CssBox(top, right, bottom, left)
 data class CssBox<out T>(val top: T, val right: T, val bottom: T, val left: T)
 


### PR DESCRIPTION
In the 2 argument version of the `box` function the behaviour is correct when assuming the same argument order as normal css, but when named parameters are used, `horizontal` and `vertical` are switched.