### PR TITLE
Update Lib.Kt   Add a convenient function

### DIFF
--- a/src/main/java/tornadofx/Lib.kt
+++ b/src/main/java/tornadofx/Lib.kt
@@ -210,6 +210,17 @@ class SortedFilteredList<T>(
 
 fun <T> List<T>.observable(): ObservableList<T> = FXCollections.observableList(this)
 fun <T> Set<T>.observable(): ObservableSet<T> = FXCollections.observableSet(this)
+
+/**
+ * For Observable<T>, Sometimes we are ONLY interested in listening to the specified property of the instance of T.
+ * This extension function is convenient for
+ * <pre>
+ * public static <E> ObservableList<E> observableArrayList(Callback<E, Observable[]> extractor)
+ * </pre>
+ */
+fun <T> List<T>.observableOn(extractor: (T) -> ObjectProperty<*>): ObservableList<T> =
+    FXCollections.observableList(this, { arrayOf(extractor(it)) })
+
 fun <K, V> Map<K, V>.observable(): ObservableMap<K, V> = FXCollections.observableMap(this)
 
 class FXTask<T>(val status: TaskStatus? = null, val func: FXTask<*>.() -> T) : Task<T>() {


### PR DESCRIPTION
  For `Observable<T>`, Sometimes we are ALSO interested in listening to the specified property of the instance of T.
  This extension function is convenient for
```java
public static <E> ObservableList<E> observableArrayList(Callback<E, Observable[]> extractor)
```

e.g. We want that whenever the name property for any User changes, this change will be
pushed as an emission.
```kotlin
        val values = FXCollections.observableArrayList<User> {                 // ---------  @
            arrayOf(it.nameProperty())
        }
        JavaFxObservable.changesOf(values)
            .subscribeBy { println(it) }
        values.add(User(1, "csy1"))
        values.add(User(2, "csy2"))
        values[0].nameProperty().value = "csy3"
```
Output
-----------------------------
ADDED 1-csy1
ADDED 2-csy2
UPDATED 1-csy3

  Though Tornadofx has a function
```kotlin
fun <T> List<T>.observable(): ObservableList<T>
```
, this function cannot specify the property of T.
If we change the scentence at "@" line to 
```kotlin
   val values = mutableListOf<User>().observable()
```
Output
-------------------------------
ADDED 1-csy1
ADDED 2-csy2

We cannot get a UPDATED change Event.