### PR TITLE
Added `Fragment` support for `TreeCell`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - menubutton builder (https://github.com/edvin/tornadofx/issues/461)
 - MenuButton.item builder
+- Added Fragment support for`TreeCell`
 
 ## [1.7.11]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 ### Changes
+- Refactoring: Moved all extension functions and properties targeting `TreeView`
+  from `Nodes.kt` to `TreeView.kt`. 
+  
+  **Note:** This could break imports in your kt files, please reimport or use `no.tornadofx.*`!
+  
 ### Additions
 
 - menubutton builder (https://github.com/edvin/tornadofx/issues/461)

--- a/src/main/java/tornadofx/Component.kt
+++ b/src/main/java/tornadofx/Component.kt
@@ -680,6 +680,8 @@ abstract class UIComponent(viewTitle: String? = "", icon: Node? = null) : Compon
     fun <S, T> TableColumn<S, T>.cellFormat(formatter: TableCell<S, T>.(T) -> Unit) = cellFormat(scope, formatter)
 
     fun <S, T, F : TableCellFragment<S, T>> TableColumn<S, T>.cellFragment(fragment: KClass<F>) = cellFragment(scope, fragment)
+
+    fun <T, F : TreeCellFragment<T>> TreeView<T>.cellFragment(fragment: KClass<F>) = cellFragment(scope, fragment)
     /**
      * Calculate a unique Node per item and set this Node as the graphic of the TableCell.
      *

--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -363,12 +363,7 @@ val <T> TableView<T>.selectedItem: T?
 val <T> TreeTableView<T>.selectedItem: T?
     get() = this.selectionModel.selectedItem?.value
 
-val <T> TreeView<T>.selectedValue: T?
-    get() = this.selectionModel.selectedItem?.value
-
 fun <T> TableView<T>.selectFirst() = selectionModel.selectFirst()
-
-fun <T> TreeView<T>.selectFirst() = selectionModel.selectFirst()
 
 fun <T> TreeTableView<T>.selectFirst() = selectionModel.selectFirst()
 
@@ -496,24 +491,10 @@ fun <T> TableView<T>.asyncItems(func: FXTask<*>.() -> Collection<T>) =
 fun <T> ComboBox<T>.asyncItems(func: FXTask<*>.() -> Collection<T>) =
         task(func = func).success { if (items == null) items = observableArrayList(it) else items.setAll(it) }
 
-fun <T> TreeView<T>.onUserSelect(action: (T) -> Unit) {
-    selectionModel.selectedItemProperty().addListener { obs, old, new ->
-        if (new != null && new.value != null)
-            action(new.value)
-    }
-}
-
 fun <T> TableView<T>.onUserDelete(action: (T) -> Unit) {
     addEventFilter(KeyEvent.KEY_PRESSED, { event ->
         if (event.code == KeyCode.BACK_SPACE && selectedItem != null)
             action(selectedItem!!)
-    })
-}
-
-fun <T> TreeView<T>.onUserDelete(action: (T) -> Unit) {
-    addEventFilter(KeyEvent.KEY_PRESSED, { event ->
-        if (event.code == KeyCode.BACK_SPACE && selectionModel.selectedItem?.value != null)
-            action(selectedValue!!)
     })
 }
 
@@ -786,9 +767,6 @@ fun <T, S : Any> TableColumn<T, S>.makeEditable(converter: StringConverter<S>): 
 }
 
 fun <T> TreeTableView<T>.populate(itemFactory: (T) -> TreeItem<T> = { TreeItem(it) }, childFactory: (TreeItem<T>) -> Iterable<T>?) =
-        populateTree(root, itemFactory, childFactory)
-
-fun <T> TreeView<T>.populate(itemFactory: (T) -> TreeItem<T> = { TreeItem(it) }, childFactory: (TreeItem<T>) -> Iterable<T>?) =
         populateTree(root, itemFactory, childFactory)
 
 /**

--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -378,11 +378,6 @@ val <T> ComboBox<T>.selectedItem: T?
 fun <S> TableView<S>.onSelectionChange(func: (S?) -> Unit) =
         selectionModel.selectedItemProperty().addListener({ observable, oldValue, newValue -> func(newValue) })
 
-fun <T> TreeView<T>.bindSelected(property: Property<T>) {
-    selectionModel.selectedItemProperty().onChange {
-        property.value = it?.value
-    }
-}
 
 fun <T> TreeTableView<T>.bindSelected(property: Property<T>) {
     selectionModel.selectedItemProperty().onChange {
@@ -390,7 +385,6 @@ fun <T> TreeTableView<T>.bindSelected(property: Property<T>) {
     }
 }
 
-fun <T> TreeView<T>.bindSelected(model: ItemViewModel<T>) = this.bindSelected(model.itemProperty)
 fun <T> TreeTableView<T>.bindSelected(model: ItemViewModel<T>) = this.bindSelected(model.itemProperty)
 
 class TableColumnCellCache<T>(private val cacheProvider: (T) -> Node) {
@@ -407,37 +401,6 @@ fun <S, T> TableColumn<S, T>.cellDecorator(decorator: TableCell<S, T>.(T) -> Uni
             if (newValue != null) decorator(cell, newValue)
         }
         cell
-    }
-}
-
-fun <S> TreeView<S>.cellFormat(formatter: (TreeCell<S>.(S) -> Unit)) {
-    cellFactory = Callback {
-        object : TreeCell<S>() {
-            override fun updateItem(item: S?, empty: Boolean) {
-                super.updateItem(item, empty)
-
-                if (item == null || empty) {
-                    textProperty().unbind()
-                    graphicProperty().unbind()
-                    text = null
-                    graphic = null
-                } else {
-                    formatter(this, item)
-                }
-            }
-        }
-    }
-}
-
-fun <S> TreeView<S>.cellDecorator(decorator: (TreeCell<S>.(S) -> Unit)) {
-    val originalFactory = cellFactory
-
-    if (originalFactory == null) cellFormat(decorator) else {
-        cellFactory = Callback { treeView: TreeView<S> ->
-            val cell = originalFactory.call(treeView)
-            cell.itemProperty().onChange { decorator(cell, cell.item) }
-            cell
-        }
     }
 }
 

--- a/src/main/java/tornadofx/TreeView.kt
+++ b/src/main/java/tornadofx/TreeView.kt
@@ -1,0 +1,150 @@
+package tornadofx
+
+import javafx.beans.property.ObjectProperty
+import javafx.beans.property.Property
+import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.property.SimpleObjectProperty
+import javafx.scene.Node
+import javafx.scene.control.TreeCell
+import javafx.scene.control.TreeView
+import javafx.util.Callback
+import tornadofx.FX.IgnoreParentBuilder.Once
+import kotlin.reflect.KClass
+
+/**
+ * Base class for all TreeCellFragments.
+ */
+abstract class TreeCellFragment<T> : ItemFragment<T>() {
+
+    val cellProperty: ObjectProperty<TreeCell<T>?> = SimpleObjectProperty()
+    var cell by cellProperty
+
+    val editingProperty = SimpleBooleanProperty(false)
+    val editing by editingProperty
+
+    open fun startEdit() { cell?.startEdit() }
+
+    open fun commitEdit(newValue: T) { cell?.commitEdit(newValue) }
+
+    open fun cancelEdit() { cell?.cancelEdit() }
+
+    open fun onEdit(op: () -> Unit) { editingProperty.onChange { if (it) op() } }
+}
+
+open class SmartTreeCell<T>(val scope: Scope = DefaultScope, treeView: TreeView<T>?): TreeCell<T>() {
+
+    private val editSupport: (TreeCell<T>.(EditEventType, T?) -> Unit)? get() = treeView.properties["tornadofx.editSupport"] as (TreeCell<T>.(EditEventType, T?) -> Unit)?
+    private val cellFormat: (TreeCell<T>.(T) -> Unit)? get() = treeView.properties["tornadofx.cellFormat"] as (TreeCell<T>.(T) -> Unit)?
+    private val cellCache: TreeCellCache<T>? get() = treeView.properties["tornadofx.cellCache"] as TreeCellCache<T>?
+    private var cellFragment: TreeCellFragment<T>? = null
+    private var fresh = true
+
+    init {
+        if (treeView != null) {
+            treeView.properties["tornadofx.cellFormatCapable"] = true
+            treeView.properties["tornadofx.cellCacheCapable"] = true
+            treeView.properties["tornadofx.editCapable"] = true
+        }
+        indexProperty().onChange {
+            if (it == -1) clearCellFragment()
+        }
+    }
+
+    override fun startEdit() {
+        super.startEdit()
+        editSupport?.invoke(this, EditEventType.StartEdit, null)
+    }
+
+    override fun commitEdit(newValue: T) {
+        super.commitEdit(newValue)
+        editSupport?.invoke(this, EditEventType.CommitEdit, newValue)
+    }
+
+    override fun cancelEdit() {
+        super.cancelEdit()
+        editSupport?.invoke(this, EditEventType.CancelEdit, null)
+    }
+
+    override fun updateItem(item: T, empty: Boolean) {
+        super.updateItem(item, empty)
+
+        if (item == null || empty) {
+            cleanUp()
+            clearCellFragment()
+        } else {
+            FX.ignoreParentBuilder = Once
+            try {
+                cellCache?.apply { graphic = getOrCreateNode(item) }
+            } finally {
+                FX.ignoreParentBuilder = FX.IgnoreParentBuilder.No
+            }
+            if (fresh) {
+                val cellFragmentType = treeView.properties["tornadofx.cellFragment"] as KClass<TreeCellFragment<T>>?
+                cellFragment = if (cellFragmentType != null) find(cellFragmentType, scope) else null
+                fresh = false
+            }
+            cellFragment?.apply {
+                editingProperty.cleanBind(editingProperty())
+                itemProperty.value = item
+                cellProperty.value = this@SmartTreeCell
+                graphic = root
+            }
+            cellFormat?.invoke(this, item)
+        }
+    }
+
+    private fun cleanUp() {
+        textProperty().unbind()
+        graphicProperty().unbind()
+        text = null
+        graphic = null
+    }
+
+    private fun clearCellFragment() {
+        cellFragment?.apply {
+            cellProperty.value = null
+            itemProperty.value = null
+            editingProperty.unbind()
+            editingProperty.value = false
+        }
+    }
+}
+
+class TreeCellCache<T>(private val cacheProvider: (T) -> Node) {
+    private val store = mutableMapOf<T, Node>()
+    fun getOrCreateNode(value: T) = store.getOrPut(value, { cacheProvider(value) })
+}
+
+fun <T> TreeView<T>.bindSelected(property: Property<T>) {
+    selectionModel.selectedItemProperty().onChange { property.value = it?.value }
+}
+
+/**
+ * Binds the currently selected object of type [T] in the given [TreeView] to the corresponding [ItemViewModel].
+ */
+fun <T> TreeView<T>.bindSelected(model: ItemViewModel<T>) = this.bindSelected(model.itemProperty)
+
+fun <T, F : TreeCellFragment<T>> TreeView<T>.cellFragment(scope: Scope = DefaultScope, fragment: KClass<F>) {
+    properties["tornadofx.cellFragment"] = fragment
+    if (properties["tornadofx.cellFormatCapable"] != true)
+        cellFactory = Callback { SmartTreeCell(scope, it) }
+}
+
+fun <S> TreeView<S>.cellFormat(scope: Scope = DefaultScope, formatter: (TreeCell<S>.(S) -> Unit)) {
+    properties["tornadofx.cellFormat"] = formatter
+    if (properties["tornadofx.cellFormatCapable"] != true) {
+        cellFactory = Callback { SmartTreeCell(scope, it) }
+    }
+}
+
+fun <S> TreeView<S>.cellDecorator(decorator: (TreeCell<S>.(S) -> Unit)) {
+    val originalFactory = cellFactory
+
+    if (originalFactory == null) cellFormat(formatter = decorator) else {
+        cellFactory = Callback { treeView: TreeView<S> ->
+            val cell = originalFactory.call(treeView)
+            cell.itemProperty().onChange { decorator(cell, cell.item) }
+            cell
+        }
+    }
+}


### PR DESCRIPTION
I realized that we are still missing `Fragment`support for `TreeCell` in a `TreeView`, this PR is adding support for it. 
@edvin  Before you merge one quick questions since we have the `TreeView`file now, should I move all other extension functions targeting `TreeView` from `Component`to the `TreeView`file. If so I will push another commit.