### PR TITLE
Minor fix in ConfigProperties (invalid returned type)

### DIFF
--- a/src/main/java/tornadofx/Component.kt
+++ b/src/main/java/tornadofx/Component.kt
@@ -71,7 +71,7 @@ class ConfigProperties(val configurable: Configurable) : Properties() {
     fun string(key: String, defaultValue: String? = null) = getProperty(key, defaultValue)
     fun boolean(key: String, defaultValue: Boolean? = false) = getProperty(key)?.toBoolean() ?: defaultValue
     fun double(key: String, defaultValue: Double? = null) = getProperty(key)?.toDouble() ?: defaultValue
-    fun int(key: String, defaultValue: Integer? = null) = getProperty(key)?.toInt() ?: defaultValue
+    fun int(key: String, defaultValue: Int? = null) = getProperty(key)?.toInt() ?: defaultValue
     fun jsonObject(key: String) = getProperty(key)?.let { Json.createReader(StringReader(it)).readObject() }
     fun jsonArray(key: String) = getProperty(key)?.let { Json.createReader(StringReader(it)).readArray() }
     inline fun <reified M : JsonModel> jsonModel(key: String) = jsonObject(key)?.toModel<M>()


### PR DESCRIPTION
Fixed minor typing issue with ConfigProperties.int() method. Now it returns Int?, as it should, instead of Any? (it happened because of java.lang.Integer usage instead of kotlin's Int).