### PR TITLE
Avoid infinite loop in error handler

### DIFF
--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -906,12 +906,20 @@ class CssSelector(vararg val rule: CssRuleSet) : Selectable {
 }
 
 class CssSelectionBlock(op: CssSelectionBlock.() -> Unit) : PropertyHolder(), SelectionHolder {
+
+    val log = Logger.getLogger("ErrorHandler")
     val selections = mutableMapOf<CssSelection, Boolean>()  // If the boolean is true, this is a refine selection
 
     init {
         val currentScope = PropertyHolder.selectionScope.get()
         PropertyHolder.selectionScope.set(this)
-        op(this)
+        try {
+            op(this)
+        } catch (e: Exception) {
+            // the CSS rule caused an error, do not let the error propagate to
+            // avoid an infinite loop in the error handler
+            log.log(Level.WARNING, "CSS rule caused an error", e)
+        }
         PropertyHolder.selectionScope.set(currentScope)
     }
 

--- a/src/main/java/tornadofx/ErrorHandler.kt
+++ b/src/main/java/tornadofx/ErrorHandler.kt
@@ -1,6 +1,5 @@
 package tornadofx
 
-import javafx.application.Platform
 import javafx.application.Platform.runLater
 import javafx.scene.control.Alert
 import javafx.scene.control.Alert.AlertType.ERROR
@@ -32,79 +31,95 @@ class DefaultErrorHandler : Thread.UncaughtExceptionHandler {
     override fun uncaughtException(t: Thread, error: Throwable) {
         log.log(Level.SEVERE, "Uncaught error", error)
 
-        val event = ErrorEvent(t, error)
-        filter(event)
-        if (!event.consumed) {
-            runLater {
-                val cause = Label(if (error.cause != null) error.cause?.message else "").apply {
-                    style = "-fx-font-weight: bold"
-                }
+        if (isCycle(error)) {
+            log.log(Level.INFO, "Detected cycle handling error, aborting.", error)
+        } else {
+            val event = ErrorEvent(t, error)
+            filter(event)
 
-                val textarea = TextArea().apply {
-                    prefRowCount = 20
-                    prefColumnCount = 50
-                    text = stringFromError(error)
-                }
-
-                Alert(ERROR).apply {
-                    title = error.message ?: "An error occured"
-                    isResizable = true
-                    headerText = if (error.stackTrace?.isEmpty() != false) "Error" else "Error in " + error.stackTrace[0].toString()
-                    dialogPane.content = VBox().apply {
-                        add(cause)
-                        if (error is RestException) {
-                            try {
-
-                                title = "HTTP Request Error: $title"
-                                form {
-                                    fieldset(error.message) {
-                                        val response = error.response
-                                        if (response != null) {
-                                            field("Status") {
-                                                label("${response.statusCode} ${response.reason}")
-                                            }
-
-                                            val c = response.text()
-
-                                            if (c != null) {
-                                                tabpane {
-                                                    background = Color.TRANSPARENT.asBackground()
-
-                                                    tab("Plain text") {
-                                                        textarea(c)
-                                                    }
-                                                    tab("HTML") {
-                                                        if (response.header("Content-Type")?.contains("html", true) == true)
-                                                            select()
-
-                                                        webview {
-                                                            engine.loadContent(c)
-                                                        }
-                                                    }
-                                                    tab("Stacktrace") {
-                                                        add(textarea)
-                                                    }
-                                                    tabs.forEach { it.isClosable = false }
-                                                }
-                                            } else {
-                                                add(textarea)
-                                            }
-                                        } else {
-                                            add(textarea)
-                                        }
-                                    }
-                                }
-
-                            } catch (e: Exception) {
-                                add(textarea)
-                            }
-                        } else {
-                            add(textarea)
-                        }
-                    }
-                    showAndWait()
+            if (!event.consumed) {
+                event.consume()
+                runLater {
+                    showErrorDialog(error)
                 }
             }
+        }
+
+    }
+
+    private fun isCycle(error: Throwable) = error.stackTrace.any {
+        it.className.startsWith("${javaClass.name}\$uncaughtException$")
+    }
+
+    private fun showErrorDialog(error: Throwable) {
+        val cause = Label(if (error.cause != null) error.cause?.message else "").apply {
+            style = "-fx-font-weight: bold"
+        }
+
+        val textarea = TextArea().apply {
+            prefRowCount = 20
+            prefColumnCount = 50
+            text = stringFromError(error)
+        }
+
+        Alert(ERROR).apply {
+            title = error.message ?: "An error occured"
+            isResizable = true
+            headerText = if (error.stackTrace?.isEmpty() != false) "Error" else "Error in " + error.stackTrace[0].toString()
+            dialogPane.content = VBox().apply {
+                add(cause)
+                if (error is RestException) {
+                    try {
+
+                        title = "HTTP Request Error: $title"
+                        form {
+                            fieldset(error.message) {
+                                val response = error.response
+                                if (response != null) {
+                                    field("Status") {
+                                        label("${response.statusCode} ${response.reason}")
+                                    }
+
+                                    val c = response.text()
+
+                                    if (c != null) {
+                                        tabpane {
+                                            background = Color.TRANSPARENT.asBackground()
+
+                                            tab("Plain text") {
+                                                textarea(c)
+                                            }
+                                            tab("HTML") {
+                                                if (response.header("Content-Type")?.contains("html", true) == true)
+                                                    select()
+
+                                                webview {
+                                                    engine.loadContent(c)
+                                                }
+                                            }
+                                            tab("Stacktrace") {
+                                                add(textarea)
+                                            }
+                                            tabs.forEach { it.isClosable = false }
+                                        }
+                                    } else {
+                                        add(textarea)
+                                    }
+                                } else {
+                                    add(textarea)
+                                }
+                            }
+                        }
+
+                    } catch (e: Exception) {
+                        add(textarea)
+                    }
+                } else {
+                    add(textarea)
+                }
+            }
+
+            showAndWait()
         }
     }
 

--- a/src/test/kotlin/tornadofx/testapps/StylesheetErrorTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/StylesheetErrorTest.kt
@@ -1,12 +1,10 @@
 package tornadofx.testapps
 
-import javafx.scene.paint.Color
 import tornadofx.App
 import tornadofx.Stylesheet
 import tornadofx.View
 import tornadofx.addClass
 import tornadofx.button
-import tornadofx.px
 import tornadofx.stackpane
 
 class StylesheetErrorTest : App(StylesheetErrorView::class, Styles::class)
@@ -19,11 +17,6 @@ class StylesheetErrorView : View() {
 
 class Styles : Stylesheet() {
     init {
-        root {
-            baseColor = Color.DARKSLATEGRAY
-            prefWidth = 300.px
-            prefHeight = 120.px
-        }
         text {
             // cannot refer to unset property
             stroke = baseColor

--- a/src/test/kotlin/tornadofx/testapps/StylesheetErrorTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/StylesheetErrorTest.kt
@@ -1,0 +1,32 @@
+package tornadofx.testapps
+
+import javafx.scene.paint.Color
+import tornadofx.App
+import tornadofx.Stylesheet
+import tornadofx.View
+import tornadofx.addClass
+import tornadofx.button
+import tornadofx.px
+import tornadofx.stackpane
+
+class StylesheetErrorTest : App(StylesheetErrorView::class, Styles::class)
+
+class StylesheetErrorView : View() {
+    override val root = stackpane {
+        button("Click here").addClass("my-button")
+    }
+}
+
+class Styles : Stylesheet() {
+    init {
+        root {
+            baseColor = Color.DARKSLATEGRAY
+            prefWidth = 300.px
+            prefHeight = 120.px
+        }
+        text {
+            // cannot refer to unset property
+            stroke = baseColor
+        }
+    }
+}

--- a/src/test/kotlin/tornadofx/tests/StylesheetErrorTest.kt
+++ b/src/test/kotlin/tornadofx/tests/StylesheetErrorTest.kt
@@ -1,0 +1,24 @@
+package tornadofx.tests
+
+import javafx.stage.Stage
+import org.junit.Test
+import org.testfx.api.FxAssert.verifyThat
+import org.testfx.framework.junit.ApplicationTest
+import org.testfx.matcher.control.LabeledMatchers.hasText
+import tornadofx.testapps.StylesheetErrorTest
+
+class StylesheetErrorTest : ApplicationTest() {
+
+    /**
+     * This will cause a stylesheet error, but should not crash the application.
+     */
+    override fun start(stage: Stage) {
+        StylesheetErrorTest().start(stage)
+    }
+
+    @Test
+    fun shouldStartApplicationWithWrongStylesheetWithoutCrashing() {
+        verifyThat(".my-button", hasText("Click here"))
+    }
+
+}


### PR DESCRIPTION
An error in a stylesheet was causing an infinite loop in the `uncaughtErrorHandler`.

This pull request fixes that.