### PR TITLE
Fix #481 - re-use StringBuilder when building CSS stylesheet.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,17 @@
             <version>${de.jensd.fontawesomefx.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jre8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>
@@ -124,7 +135,7 @@
     </scm>
 
     <build>
-        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
 
         <pluginManagement>
             <plugins>
@@ -152,13 +163,14 @@
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>process-sources</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>test-compile</id>
+                        <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -70,17 +70,6 @@
             <version>${de.jensd.fontawesomefx.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jre8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
-            <version>${kotlin.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <distributionManagement>
@@ -135,7 +124,7 @@
     </scm>
 
     <build>
-        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
 
         <pluginManagement>
             <plugins>
@@ -163,14 +152,13 @@
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>compile</phase>
+                        <phase>process-sources</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>test-compile</id>
-                        <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
                         </goals>

--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -35,7 +35,9 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
 interface Rendered {
-    fun render(): String
+    fun render() = buildString { render(this) }
+
+    fun render(builder: StringBuilder)
 }
 
 interface Scoped {
@@ -475,12 +477,22 @@ open class Stylesheet(vararg val imports: KClass<out Stylesheet>) : SelectionHol
         selections -= selection
     }
 
-    override fun render() = imports.map { "@import url(css://${it.java.name})" }.joinToString(separator = "\n", postfix = "\n") +
-            selections.joinToString(separator = "") { it.render() }
+    override fun render(builder: StringBuilder) {
+        builder.apply {
+            imports.forEach { import ->
+                append("@import url(css://").append(import.java.name).append("\n")
+            }
+            selections.forEach { selection ->
+                selection.render(builder)
+            }
+        }
+    }
 
     val base64URL: URL
         get() {
-            val content = Base64.getEncoder().encodeToString(render().toByteArray(StandardCharsets.UTF_8))
+            val builder = StringBuilder(512)
+            render(builder)
+            val content = Base64.getEncoder().encodeToString(builder.toString().toByteArray(StandardCharsets.UTF_8))
             return URL("css://$content:64")
         }
 
@@ -873,22 +885,22 @@ open class PropertyHolder {
 class CssSelection(val selector: CssSelector, op: CssSelectionBlock.() -> Unit) : Rendered {
     val block = CssSelectionBlock(op)
 
-    override fun render() = render(emptyList(), false)
+    override fun render(builder: StringBuilder) = render(builder, emptyList(), false)
 
-    fun render(parents: List<String>, refine: Boolean): String = buildString {
+    fun render(builder: StringBuilder, parents: List<String>, refine: Boolean) {
         val ruleStrings = selector.strings(parents, refine)
         block.mergedProperties.let {
             // TODO: Handle custom renderer
             if (it.isNotEmpty()) {
-                append("${ruleStrings.joinToString()} {\n")
+                builder.append(ruleStrings.joinToString()).append(" {\n")
                 for ((name, value) in it) {
-                    append("    $name: ${value.second?.invoke(value.first) ?: PropertyHolder.toCss(value.first)};\n")
+                    builder.append("    $name: ${value.second?.invoke(value.first) ?: PropertyHolder.toCss(value.first)};\n")
                 }
-                append("}\n")
+                builder.append("}\n")
             }
         }
         for ((selection, refine) in block.selections) {
-            append(selection.render(ruleStrings, refine))
+            selection.render(builder, ruleStrings, refine)
         }
     }
 }
@@ -901,7 +913,12 @@ class CssSelector(vararg val rule: CssRuleSet) : Selectable {
     }
 
     override fun toSelection() = this
-    fun strings(parents: List<String>, refine: Boolean) = rule.map { it.render() }.cartesian(parents, refine)
+
+    fun strings(parents: List<String>,
+                refine: Boolean): List<String> {
+        return rule.map { it.render() }
+                .cartesian(parents, refine)
+    }
 
     fun simpleRender() = rule.map { it.render() }.joinToString()
 }
@@ -966,9 +983,11 @@ class CssSelectionBlock(op: CssSelectionBlock.() -> Unit) : PropertyHolder(), Se
 fun mixin(op: CssSelectionBlock.() -> Unit) = CssSelectionBlock(op)
 
 class CssRuleSet(val rootRule: CssRule, vararg val subRule: CssSubRule) : Selectable, Scoped, Rendered {
-    override fun render() = buildString {
-        append(rootRule.render())
-        subRule.forEach { append(it.render()) }
+    override fun render(builder: StringBuilder) {
+        builder.apply {
+            rootRule.render(builder)
+            subRule.forEach { it.render(builder) }
+        }
     }
 
     override fun toRuleSet() = this
@@ -998,14 +1017,20 @@ class CssRule(val prefix: String, name: String, snakeCase: Boolean = true) : Sel
 
     val name = if (snakeCase) name.camelToSnake() else name
 
-    override fun render() = "$prefix$name"
+    override fun render(builder: StringBuilder) {
+        builder.append(prefix).append(name)
+    }
+
     override fun toRuleSet() = CssRuleSet(this)
     override fun toSelection() = toRuleSet().toSelection()
     override fun append(rule: CssSubRule) = CssRuleSet(this, rule)
 }
 
 class CssSubRule(val rule: CssRule, val relation: Relation) : Rendered {
-    override fun render() = "${relation.render()}${rule.render()}"
+    override fun render(builder: StringBuilder) {
+        relation.render(builder)
+        rule.render(builder)
+    }
 
     enum class Relation(val symbol: String) : Rendered {
         REFINE(""),
@@ -1025,7 +1050,9 @@ class CssSubRule(val rule: CssRule, val relation: Relation) : Rendered {
             }
         }
 
-        override fun render() = symbol
+        override fun render(builder: StringBuilder) {
+            builder.append(symbol)
+        }
     }
 }
 
@@ -1033,8 +1060,12 @@ class CssSubRule(val rule: CssRule, val relation: Relation) : Rendered {
 
 class InlineCss : PropertyHolder(), Rendered {
     // TODO: Handle custom renderer
-    override fun render() = mergedProperties.entries.joinToString(separator = "") {
-        " ${it.key}: ${it.value.second?.invoke(it.value.first) ?: toCss(it.value.first)};"
+    override fun render(builder: StringBuilder) {
+        mergedProperties.entries.forEach {
+            builder.append(' ').append(it.key).append(": ")
+                    .append(it.value.second?.invoke(it.value.first) ?: toCss(it.value.first))
+                    .append(';')
+        }
     }
 }
 

--- a/src/test/kotlin/tornadofx/tests/StylesheetTest.kt
+++ b/src/test/kotlin/tornadofx/tests/StylesheetTest.kt
@@ -546,6 +546,107 @@ class StylesheetTest {
         }
     }
 
+    @Test
+    fun largeStylesheetCanBeRenderedWithoutErrors() {
+        withTimer("large-stylesheet") {
+            stylesheet {
+                s(barChart) {
+                    barFill = Color.RED
+                }
+                s(imageView) {
+                    effect = InnerShadow(BlurType.GAUSSIAN, Color.GREENYELLOW, 7.0, 1.0, 1.0, 1.0)
+                }
+                val hover = mixin {
+                    and(hover) {
+                        backgroundColor += RadialGradient(90.0, 0.5, 0.5, 0.5, 0.25, true, CycleMethod.REPEAT, Stop(0.0, Color.WHITE), Stop(0.5, c("error")), Stop(1.0, Color.BLACK))
+                    }
+                }
+                val wrap = mixin {
+                    padding = box(1.em)
+                    borderColor += box(LinearGradient(0.0, 0.0, 10.0, 10.0, false, CycleMethod.REFLECT, Stop(0.0, Color.RED), Stop(1.0, c(0.0, 1.0, 0.0))))
+                    borderWidth += box(5.px)
+                    backgroundRadius += box(25.px)
+                    borderRadius += box(25.px)
+                    +hover
+                }
+
+                box {
+                    +wrap
+                    backgroundColor += RadialGradient(90.0, 0.5, 0.5, 0.5, 0.25, true, CycleMethod.REPEAT, Stop(0.0, Color.WHITE), Stop(1.0, Color.BLACK))
+                    spacing = 5.px
+
+                    label {
+                        +wrap
+                        font = Font.font(14.0)
+                        fontWeight = FontWeight.BOLD
+                        textFill = c("white")
+                        rotate = .95.turn
+                        translateX = .5.inches
+                        minHeight = 6.em
+                        scaleX = 2
+                        scaleY = .75
+                    }
+                }
+                s(a, b, c) {
+                    s(d, e, f) {
+                        s(g, h, i) {
+                            textFill = Color.BLUE
+                        }
+                    }
+                }
+            }
+        } shouldEqual {
+                """
+            .bar-chart {
+                -fx-bar-fill: rgba(255, 0, 0, 1);
+            }
+            .image-view {
+                -fx-effect: innershadow(gaussian, rgba(173, 255, 47, 1), 7.0, 1.0, 1.0, 1.0);
+            }
+            .box {
+                -fx-padding: 1em 1em 1em 1em;
+                -fx-border-color: linear-gradient(from 0.0px 0.0px to 10.0px 10.0px, reflect, rgba(255, 0, 0, 1) 0.0%, rgba(0, 255, 0, 1) 100.0%) linear-gradient(from 0.0px 0.0px to 10.0px 10.0px, reflect, rgba(255, 0, 0, 1) 0.0%, rgba(0, 255, 0, 1) 100.0%) linear-gradient(from 0.0px 0.0px to 10.0px 10.0px, reflect, rgba(255, 0, 0, 1) 0.0%, rgba(0, 255, 0, 1) 100.0%) linear-gradient(from 0.0px 0.0px to 10.0px 10.0px, reflect, rgba(255, 0, 0, 1) 0.0%, rgba(0, 255, 0, 1) 100.0%);
+                -fx-border-width: 5px 5px 5px 5px;
+                -fx-background-radius: 25px 25px 25px 25px;
+                -fx-border-radius: 25px 25px 25px 25px;
+                -fx-background-color: radial-gradient(focus-angle 90.0deg, focus-distance 50.0% , center 50.0% 50.0%, radius 25.0%, repeat, rgba(255, 255, 255, 1) 0.0%, rgba(0, 0, 0, 1) 100.0%);
+                -fx-spacing: 5px;
+            }
+            .box:hover {
+                -fx-background-color: radial-gradient(focus-angle 90.0deg, focus-distance 50.0% , center 50.0% 50.0%, radius 25.0%, repeat, rgba(255, 255, 255, 1) 0.0%, rgba(255, 0, 255, 1) 50.0%, rgba(0, 0, 0, 1) 100.0%);
+            }
+            .box .label {
+                -fx-padding: 1em 1em 1em 1em;
+                -fx-border-color: linear-gradient(from 0.0px 0.0px to 10.0px 10.0px, reflect, rgba(255, 0, 0, 1) 0.0%, rgba(0, 255, 0, 1) 100.0%) linear-gradient(from 0.0px 0.0px to 10.0px 10.0px, reflect, rgba(255, 0, 0, 1) 0.0%, rgba(0, 255, 0, 1) 100.0%) linear-gradient(from 0.0px 0.0px to 10.0px 10.0px, reflect, rgba(255, 0, 0, 1) 0.0%, rgba(0, 255, 0, 1) 100.0%) linear-gradient(from 0.0px 0.0px to 10.0px 10.0px, reflect, rgba(255, 0, 0, 1) 0.0%, rgba(0, 255, 0, 1) 100.0%);
+                -fx-border-width: 5px 5px 5px 5px;
+                -fx-background-radius: 25px 25px 25px 25px;
+                -fx-border-radius: 25px 25px 25px 25px;
+                -fx-font: normal 14.0pt "System";
+                -fx-font-weight: 700;
+                -fx-text-fill: rgba(255, 255, 255, 1);
+                -fx-rotate: 0.95turn;
+                -fx-translate-x: 0.5in;
+                -fx-min-height: 6em;
+                -fx-scale-x: 2;
+                -fx-scale-y: 0.75;
+            }
+            .box .label:hover {
+                -fx-background-color: radial-gradient(focus-angle 90.0deg, focus-distance 50.0% , center 50.0% 50.0%, radius 25.0%, repeat, rgba(255, 255, 255, 1) 0.0%, rgba(255, 0, 255, 1) 50.0%, rgba(0, 0, 0, 1) 100.0%);
+            }
+            .a .d .g, .a .d .h, .a .d .i, .a .e .g, .a .e .h, .a .e .i, .a .f .g, .a .f .h, .a .f .i, .b .d .g, .b .d .h, .b .d .i, .b .e .g, .b .e .h, .b .e .i, .b .f .g, .b .f .h, .b .f .i, .c .d .g, .c .d .h, .c .d .i, .c .e .g, .c .e .h, .c .e .i, .c .f .g, .c .f .h, .c .f .i {
+                -fx-text-fill: rgba(0, 0, 255, 1);
+            }
+            """
+        }
+    }
+
+    private fun <T> withTimer(name: String, action: () -> T): T {
+        val startTime = System.currentTimeMillis()
+        val result = action()
+        println("$name (Total time): ${System.currentTimeMillis() - startTime} ms")
+        return result
+    }
+
     private fun stylesheet(op: Stylesheet.() -> Unit) = Stylesheet().apply(op)
     infix fun Stylesheet.shouldEqual(op: () -> String) = Assert.assertEquals(op().strip(), render().strip())
     infix fun Color.shouldEqual(other: Color) = Assert.assertEquals(other.toString(), toString())


### PR DESCRIPTION
Hello again!

I did what I suggested in ticket #481, it was not too hard...

But the result totally surprised me.

<img width="566" alt="screen shot 2017-10-05 at 15 52 16" src="https://user-images.githubusercontent.com/1901277/31231339-e83732b6-a9e6-11e7-9a13-49535e8e6e78.png">

Looks like it didn't make any difference... it anything, it got a little bit slower. I know from previous experience that using a single builder instead of constantly appending Strings should have made a positive difference, but as always with performance, you can never be sure.

I decided to make a pull request anyway because with further profiling, this may turn out to be good anyway. But feel free to decline it as it did not deliver on the improved performance it was supposed to bring.

Notice that I wrote a test that creates a largish spreadsheet and prints how long it took (that's how I got this chart). I would consider keeping that and using it to make sure that when you refactor the CSS, you don't make it a lot slower... It is already quite sluggish, to be honest... How can a CSS with a few dozen lines take 200ms to render? I would expect an order of magnitude less... but the problem seems to be somewhere else :)

Further profiling is required.