### PR TITLE
Add a few tests for Collections.kt

### DIFF
--- a/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
+++ b/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
@@ -1,0 +1,70 @@
+package tornadofx.tests
+
+import org.junit.Test
+import tornadofx.move
+import tornadofx.moveAt
+import kotlin.test.assertEquals
+
+class CollectionsTest {
+
+    @Test
+    fun testMoveWithValidIndex() {
+        val list = mutableListOf(1, 2, 3, 4)
+
+        list.move(2, 3)
+
+        assertEquals(mutableListOf(1, 3, 4, 2), list)
+    }
+
+    @Test
+    fun testMoveWithInvalidIndex() {
+        val list = mutableListOf(1, 2, 3, 4)
+
+        try {
+            list.move(2, 102)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+
+    @Test
+    fun testMoveWithInvalidItem() {
+        val list = mutableListOf(1, 2, 3, 4)
+
+        list.move(10, 1)
+
+        assertEquals(mutableListOf(1, 2, 3, 4), list)
+    }
+
+    @Test
+    fun testMoveAtForward() {
+        val list = mutableListOf(1, 2, 3, 4)
+        val newIndex = 2
+
+        list.moveAt(0, newIndex)
+
+        assertEquals(1, list[newIndex])
+    }
+
+    @Test
+    fun testMoveAtBackward() {
+        val list = mutableListOf(1, 2, 3, 4)
+        val newIndex = 0
+
+        list.moveAt(2, newIndex)
+
+        assertEquals(3, list[newIndex])
+    }
+
+    @Test
+    fun testMoveAtWithInvalidNewIndex() {
+        val list = mutableListOf(1, 2, 3, 4)
+        val newIndex = 10
+
+        try {
+            list.moveAt(2, newIndex)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+}


### PR DESCRIPTION
This is my first time contributing to this project so I decided to write a few tests.

I added a few tests for the Collections.kt extension methods. The `moveAll` method validates the input index, `move` and `moveAt` don't so I added some failing tests.

I think `moveAt` has a bug:
```
if (oldIndex > newIndex)
    add(newIndex, item)
else
    add(newIndex - 1, item)
```
It should always use `add(newIndex, item)`

I would be happy to create a pull request fixing the failing tests. Also let me know if more tests is something you would be interested in. I have a selfish reason for writing them (#hacktoberfest).