### PR TITLE
#491 - fixed Node.findParentOfType + test

### DIFF
--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -44,6 +44,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.*
 import kotlin.reflect.KClass
+import kotlin.reflect.full.safeCast
 
 fun <S, T> TableColumnBase<S, T>.hasClass(className: String) = styleClass.contains(className)
 fun <S, T> TableColumnBase<S, T>.hasClass(className: CssRule) = hasClass(className.name)
@@ -988,9 +989,9 @@ inline fun <reified T:Any> Node.findParent(): T? = findParentOfType(T::class)
 @Suppress("UNCHECKED_CAST")
 fun <T : Any> Node.findParentOfType(parentType: KClass<T>): T? {
     if (parent == null) return null
-    (parent as? T)?.also { return it }
+    parentType.safeCast(parent)?.also { return it }
     val uicmp = parent.uiComponent<UIComponent>()
-    (uicmp as? T)?.also { return it }
+    parentType.safeCast(uicmp)?.also { return it }
     return parent?.findParentOfType(parentType)
 }
 

--- a/src/test/kotlin/tornadofx/tests/InternalWindowClosingTest.kt
+++ b/src/test/kotlin/tornadofx/tests/InternalWindowClosingTest.kt
@@ -1,0 +1,38 @@
+package tornadofx.tests
+
+import javafx.scene.Scene
+import javafx.scene.layout.Pane
+import javafx.stage.Stage
+import org.junit.Test
+import org.testfx.api.FxToolkit
+import tornadofx.*
+import kotlin.test.*
+
+/**
+ * Tests if it's possible to open an [InternalWindow] instance and then close it using [UIComponent.close]
+ */
+class InternalWindowClosingTest {
+    val primaryStage: Stage = FxToolkit.registerPrimaryStage()
+
+    @Test
+    fun testClosing() {
+        val owner = Pane()
+
+        val view = object : View() {
+            override val root = pane()
+            fun executeClose() { close() }
+        }
+
+        FxToolkit.setupFixture {
+            primaryStage.scene = Scene(owner)
+            primaryStage.show()
+            val iw = InternalWindow(null, true, true, true);
+            iw.open(view, owner)
+            assertNotNull(iw.scene)
+            assertTrue(view.isDocked)
+            view.executeClose()
+            assertNull(iw.scene)
+            assertFalse(view.isDocked)
+        }
+    }
+}


### PR DESCRIPTION
Fixed for #491 (broken Node.findParentOfType)

`as?` operator does not work correctly when it comes to erasure and in effect any non-null object was returned, which caused `ClassCastException` at later point.

Fortunately `KClass` instance was available, so it was possible to make truly type-aware safe cast.

A test case has been added as well.