### PR TITLE
#485 - fixed ItemViewModel not updating an underlying poko

### DIFF
--- a/src/main/java/tornadofx/ViewModel.kt
+++ b/src/main/java/tornadofx/ViewModel.kt
@@ -533,6 +533,10 @@ open class ItemViewModel<T> @JvmOverloads constructor(initialValue: T? = null, v
     inline fun <reified N : Any, ReturnType : Property<N>> bind(property: KMutableProperty1<T, N>, autocommit: Boolean = false, forceObjectProperty: Boolean = false): ReturnType
             = bind(autocommit, forceObjectProperty) { item?.observable(property) }
 
+    @JvmName("bindMutableNullableField")
+    inline fun <reified N : Any, ReturnType : Property<N>> bind(property: KMutableProperty1<T, N?>, autocommit: Boolean = false, forceObjectProperty: Boolean = false): ReturnType
+            = bind(autocommit, forceObjectProperty) { item?.observable(property) as Property<N> } //this may look quirky, but is de facto safe; a Java property is nullable anyway
+
     @JvmName("bindProperty")
     inline fun <reified N : Any, reified PropertyType : Property<N>, ReturnType : PropertyType> bind(property: KProperty1<T, PropertyType>, autocommit: Boolean = false, forceObjectProperty: Boolean = false): ReturnType
             = bind(autocommit, forceObjectProperty) { item?.let { property.get(it) } }

--- a/src/test/kotlin/tornadofx/tests/PersonPoko.kt
+++ b/src/test/kotlin/tornadofx/tests/PersonPoko.kt
@@ -1,0 +1,6 @@
+package tornadofx.tests
+
+data class PersonPoko(var name: String, var phone: String?, var email: String?, var age: Int, var parent: PersonPoko?) {
+    constructor(name: String, age: Int) : this(name, null, null, age, null)
+    constructor() : this("", 18)
+}

--- a/src/test/kotlin/tornadofx/tests/ViewModelTest.kt
+++ b/src/test/kotlin/tornadofx/tests/ViewModelTest.kt
@@ -1,5 +1,6 @@
 package tornadofx.tests
 
+import javafx.beans.property.ObjectProperty
 import javafx.beans.property.Property
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
@@ -11,6 +12,7 @@ import org.junit.Assert.*
 import org.junit.Test
 import org.testfx.api.FxToolkit
 import tornadofx.*
+import kotlin.reflect.KMutableProperty1
 
 open class ViewModelTest {
     val primaryStage: Stage = FxToolkit.registerPrimaryStage()
@@ -87,9 +89,60 @@ open class ViewModelTest {
         val model = JavaPersonModel(person)
 
         model.name.value = "Jay"
+        assertEquals(model.name.value, "Jay")
         assertEquals(person.name, "John")
         model.commit()
+        assertEquals(model.name.value, "Jay")
         assertEquals(person.name, "Jay")
+
+        model.name.value = null
+        assertNull(model.name.value)
+        assertNotNull(person.name)
+
+        model.commit()
+        assertNull(model.name.value)
+        assertNull(person.name)
+    }
+
+    @Test fun poko_commit() {
+        val person = PersonPoko()
+        person.name = "John"
+        person.phone = "777"
+        val model = PersonPokoModel(person)
+
+        //testing non-nullable field
+        model.name.value = "Jay"
+        assertEquals("Jay", model.name.value)
+        assertEquals("John", person.name)
+        model.commit()
+        assertEquals("Jay", model.name.value)
+        assertEquals("Jay", person.name)
+
+        model.name.value = null
+        assertNull(model.name.value)
+        assertNotNull(person.name)
+
+        /*model.commit() //IllegalArgumentException @ JavaFX Thread
+        assertNull(model.name.value) //null, assertion passes
+        assertNull(person.name) //not null, assertion fails*/
+
+        model.rollback() //next commit would cause IllegalArgumentException, we don't want that
+
+        //testing nullable field
+        model.phone.value = "555"
+        assertEquals("555", model.phone.value)
+        assertEquals("777", person.phone)
+        model.commit()
+        assertEquals("555", model.phone.value)
+        assertEquals("555", person.phone)
+
+        model.phone.value = null
+        assertNull(model.phone.value)
+        assertNotNull(person.phone)
+
+        model.commit()
+        assertNull(model.phone.value)
+        assertNull(person.phone)
     }
 
     @Test fun var_commit_check_dirty_state() {
@@ -181,4 +234,10 @@ class JavaPersonModel(person: JavaPerson) : ViewModel() {
 // Kotlin var property
 class PersonVarModel(person: Person) : ViewModel() {
     val name = bind { person.observable(Person::name) }
+}
+
+//Kotlin nullable and non-nullable property in ItemViewModel
+class PersonPokoModel(item : PersonPoko): ItemViewModel<PersonPoko>(item) {
+    val name = bind(PersonPoko::name)
+    val phone = bind(PersonPoko::phone)
 }


### PR DESCRIPTION
bind() method in ItemViewModel is heavily overloaded and mutable nullable property falled into: bind(KProperty1<T, N?>, Boolean, Boolean) because bind(KMutableProperty1<T, N>, Boolean, Boolean) was no match because of non-nullable N and most generic variant has been chosen.

So I added another method, bind(KMutableProperty1<T, N?>, Boolean, Boolean) which is invoked in this particular case. Non-nullable values are bound using already existing method, and the nullable ones are matching against a KMutableProperty instead on KProperty (which resulted in being read only).

Casting Property<N?> to property Property<N> may look suspicious at first glance, but underneath is Java property object, which is actually Property<N!>, so it's as safe as it can be.

Added a test as well - tests how ItemViewModel handles changes both for non-nullable and nullable value. Checks if value is commited to nullable field.