### PR TITLE
Some additonal eyecandy for async tasks

### DIFF
--- a/src/main/java/tornadofx/Async.kt
+++ b/src/main/java/tornadofx/Async.kt
@@ -1,0 +1,140 @@
+package tornadofx
+
+import javafx.beans.property.ReadOnlyBooleanProperty
+import javafx.beans.property.ReadOnlyBooleanWrapper
+import javafx.concurrent.Task
+import javafx.scene.Node
+import javafx.scene.layout.BorderPane
+import javafx.util.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Covers node with overlay (by default - an instance of [MaskPane]) until [latch] is released by another thread.
+ * It's useful when more control over async execution is needed, like:
+ * * A task already have its thread and overlay should be visible until some callback is invoked (it should invoke
+ * [CountDownLatch.countDown] or [Latch.release]) in order to unlock UI. Keep in mind that if [latch] is not released
+ * and [timeout] is not set, overlay may never get removed.
+ * * An overlay should be removed after some time, even if task is getting unresponsive (use [timeout] for this).
+ * * In addition to masking UI, you need an access to property indicating if background process is running;
+ * [Latch.lockedProperty] serves exactly that purpose.
+ * * More threads are involved in task execution. You can create a [CountDownLatch] for number of workers, call
+ * [CountDownLatch.countDown] from each of them when it's done and overlay will stay visible until all workers finish
+ * their jobs.
+ *
+ * @param latch an instance of [CountDownLatch], usage of [Latch] is recommended.
+ * @param timeout timeout after which overlay will be removed anyway. Can be `null` (which means no timeout).
+ * @param overlayNode optional custom overlay node. For best effect set transparency.
+ *
+ * # Example
+ *
+ * ```kotlin
+ * val latch = Latch()
+ * root.runAsyncWithOverlay(latch) ui {
+ *   //UI action
+ * }
+ *
+ * Thread({
+ *   Thread.sleep(2000)
+ *   latch.release()
+ * }).start()
+ * ```
+ */
+@JvmOverloads
+fun Node.runAsyncWithOverlay(latch: CountDownLatch, timeout: Duration? = null, overlayNode: Node = MaskPane()): Task<Boolean> {
+    return if(timeout == null) {
+        runAsyncWithOverlay(overlayNode) { latch.await(); true }
+    } else {
+        runAsyncWithOverlay(overlayNode) { latch.await(timeout.toMillis().toLong(), TimeUnit.MILLISECONDS) }
+    }
+}
+
+/**
+ * Runs given task in background thread, covering node with overlay (default one is [MaskPane]) until task is done.
+ *
+ * # Example
+ *
+ * ```kotlin
+ * root.runAsyncWithOverlay {
+ *   Thread.sleep(2000)
+ * } ui {
+ *   //UI action
+ * }
+ * ```
+ *
+ * @param overlayNode optional custom overlay node. For best effect set transparency.
+ */
+@JvmOverloads
+fun <T : Any> Node.runAsyncWithOverlay(overlayNode: Node = MaskPane(), op: () -> T): Task<T> {
+    val overlayContainer = stackpane { add(overlayNode) }
+
+    replaceWith(overlayContainer)
+    overlayContainer.children.add(0,this)
+
+    return task {
+        try { op() }
+        finally { runLater { overlayContainer.replaceWith(this@runAsyncWithOverlay) } }
+    }
+}
+
+/**
+ * A basic mask pane, intended for blocking gui underneath. Styling example:
+ *
+ * ```css
+ * .mask-pane {
+ *     -fx-background-color: rgba(0,0,0,0.5);
+ *     -fx-accent: aliceblue;
+ * }
+ *
+ * .mask-pane > .progress-indicator {
+ *     -fx-max-width: 300;
+ *     -fx-max-height: 300;
+ * }
+ * ```
+ */
+class MaskPane : BorderPane() {
+    init {
+        addClass("mask-pane")
+        center = progressindicator()
+    }
+
+    override fun getUserAgentStylesheet() = MaskPane::class.java.getResource("maskpane.css").toExternalForm()!!
+}
+
+/**
+ * Adds some superpowers to good old [CountDownLatch], like exposed [lockedProperty] or ability to release latch
+ * immediately.
+ *
+ * All documentation of superclass applies here. Default behavior has not been altered.
+ */
+class Latch(count: Int) : CountDownLatch(count) {
+    /**
+     * Initializes latch with count of `1`, which means that the first invocation of [countDown] will allow all
+     * waiting threads to proceed.
+     */
+    constructor() : this(1)
+
+    private val lockedProperty by lazy { ReadOnlyBooleanWrapper(locked) }
+
+    /**
+     * Locked state of this latch exposed as a property.
+     */
+    fun lockedProperty() : ReadOnlyBooleanProperty = lockedProperty.readOnlyProperty
+
+    /**
+     * Locked state of this latch.
+     */
+    val locked get() = count > 0L
+
+    /**
+     * Releases latch immediately and allows waiting thread(s) to proceed. Can be safely used if this latch has been
+     * initialized with `count` of `1`, should be used with care otherwise - [countDown] invocations ar preferred in
+     * such cases.
+     */
+    fun release() = (1..count).forEach { countDown() } //maybe not the prettiest way, but works fine
+
+    override fun countDown() {
+        super.countDown()
+        lockedProperty.set(locked)
+    }
+}

--- a/src/main/resources/tornadofx/maskpane.css
+++ b/src/main/resources/tornadofx/maskpane.css
@@ -1,0 +1,9 @@
+.mask-pane {
+    -fx-background-color: rgba(0,0,0,0.5);
+    -fx-accent: aliceblue;
+}
+
+.mask-pane > .progress-indicator {
+    -fx-max-width: 300;
+    -fx-max-height: 300;
+}

--- a/src/test/kotlin/tornadofx/tests/AsyncTest.kt
+++ b/src/test/kotlin/tornadofx/tests/AsyncTest.kt
@@ -1,0 +1,90 @@
+package tornadofx.tests
+
+import javafx.scene.control.Button
+import javafx.scene.layout.BorderPane
+import javafx.scene.layout.Pane
+import javafx.scene.layout.StackPane
+import javafx.stage.Stage
+import org.junit.Assert
+import org.junit.Test
+import org.testfx.api.FxToolkit
+import tornadofx.*
+import java.util.concurrent.CountDownLatch
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class AsyncTest {
+    val primaryStage: Stage = FxToolkit.registerPrimaryStage()
+
+    @Test
+    fun runAsyncWithOverlay() {
+        //Initially container has embedded node
+        val container = BorderPane()
+        val node = Pane()
+        val mask = Pane()
+
+        container.center = node
+        assertEquals(container.center, node)
+
+        //This latch will be used to control asynchronously executed task, it's a part of the test
+        val latch = Latch()
+        assertTrue(latch.locked)
+
+        //This is a standard CountDownLatch and will be used to synchronize test thread with application thread
+        val appThreadLatch = CountDownLatch(1)
+
+        //ui is needed here because only after task is executed we can check if overlay is removed propertly
+        //and it can only be used from within a UIComponent, so we need a temporary object
+        val component = object : Controller() {
+            fun run() = node.runAsyncWithOverlay(latch, null, mask) ui { appThreadLatch.countDown() }
+        }
+        component.run()
+
+        //Until latch is released, a node is replaced with StackPane containing both the original component and the mask
+        assertNotEquals(node, container.center)
+        assertTrue(container.center is StackPane)
+        assertTrue((container.center as StackPane).children.containsAll(setOf(node, mask)))
+
+        //The working thread (test thread in this case) proceeds, which should result in removing overlay
+        latch.release()
+        assertFalse(latch.locked)
+
+        //Waiting until we have confirmed post-task ui execution
+        appThreadLatch.await()
+
+        //At this point overlay should be removed and node should be again in its original place
+        assertEquals(node, container.center)
+    }
+
+    @Test
+    fun latch() {
+        //Latch set for 5 concurrent tasks
+        val count = 5
+        val latch = Latch(count)
+        val button = Button()
+
+        assertFalse(button.disabledProperty().value)
+
+        //Button should stay disabled until all tasks are over
+        button.disableWhen(latch.lockedProperty())
+
+        (1..count).forEach {
+            assertTrue(button.disabledProperty().value)
+            assertTrue(latch.locked)
+            assertTrue(latch.lockedProperty().value)
+            latch.countDown()
+            //Latch count should decrease after each iteration
+            Assert.assertEquals(count, (it + latch.count).toInt())
+        }
+
+        assertFalse(button.disabledProperty().value)
+        assertFalse(latch.locked)
+
+        //Should have no effect anyway
+        latch.release()
+        assertFalse(button.disabledProperty().value)
+        assertFalse(latch.locked)
+    }
+}


### PR DESCRIPTION
A node (any node) can now be covered with customizable overlay until background task is executed.  A new Latch class allows for finer control, including multithreading, timeouts and bindings.

Docs with some basic examples and test included.

----

I'm working on an application built on top of TFX and while `runAsyncWithProgress` is very cool (in fact, inspired me to do this), I missed the ability to mask entire UI (or only part of it) with transluscent overlay. And I have some legacy, callback-based API which doesn't really play along with mechanisms already built into TFX.

This commit fills the gap for me - a new `Node.runAsyncWithOverlay` method allows to block UI, and Latch (which is just a JavaFX friendly extension of `CountDownLatch`) gives some additional control.
