### PR TITLE
Fix/async

### DIFF
--- a/src/main/java/tornadofx/Async.kt
+++ b/src/main/java/tornadofx/Async.kt
@@ -18,6 +18,11 @@ import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
+import java.util.logging.Level
+import java.util.logging.Logger
+
+internal val log = Logger.getLogger("tornadofx.async")
+internal val dummyUncaughtExceptionHandler = Thread.UncaughtExceptionHandler { t, e -> log.log(Level.WARNING, e) { "Exception in ${t?.name ?: "?"}: ${e?.message ?: "?"}" } }
 
 internal val tfxThreadPool = Executors.newCachedThreadPool(object : ThreadFactory {
     private val threadCounter = AtomicLong(0L)
@@ -25,7 +30,7 @@ internal val tfxThreadPool = Executors.newCachedThreadPool(object : ThreadFactor
 })
 
 fun <T> task(taskStatus: TaskStatus? = null, func: FXTask<*>.() -> T): Task<T> = FXTask(taskStatus, func = func).apply {
-    setOnFailed({ Thread.getDefaultUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), exception) })
+    setOnFailed({ (Thread.getDefaultUncaughtExceptionHandler() ?: dummyUncaughtExceptionHandler).uncaughtException(Thread.currentThread(), exception) })
     tfxThreadPool.execute(this)
 }
 
@@ -334,8 +339,9 @@ class FXTimerTask(val op: () -> Unit, val timer: Timer) : TimerTask() {
 }
 
 class FXTask<T>(val status: TaskStatus? = null, val func: FXTask<*>.() -> T) : Task<T>() {
-    val completedProperty: ReadOnlyBooleanProperty = SimpleBooleanProperty(false)
-    val completed by completedProperty
+    private var internalCompleted = ReadOnlyBooleanWrapper(false)
+    val completedProperty: ReadOnlyBooleanProperty get() = internalCompleted.readOnlyProperty
+    val completed: Boolean get() = completedProperty.value
 
     override fun call() = func(this)
 
@@ -344,15 +350,15 @@ class FXTask<T>(val status: TaskStatus? = null, val func: FXTask<*>.() -> T) : T
     }
 
     override fun succeeded() {
-        (completedProperty as BooleanProperty).value = true
+        internalCompleted.value = true
     }
 
     override fun failed() {
-        (completedProperty as BooleanProperty).value = true
+        internalCompleted.value = true
     }
 
     override fun cancelled() {
-        (completedProperty as BooleanProperty).value = true
+        internalCompleted.value = true
     }
 
     override public fun updateProgress(workDone: Long, max: Long) {

--- a/src/test/kotlin/tornadofx/tests/AsyncTest.kt
+++ b/src/test/kotlin/tornadofx/tests/AsyncTest.kt
@@ -87,30 +87,4 @@ class AsyncTest {
         assertFalse(button.disabledProperty().value)
         assertFalse(latch.locked)
     }
-
-    @Test
-    fun taskCancel() {
-        val latch = Latch()
-        val holder = object { var v = false }
-
-        val task = runAsync {
-            while(!this.isCancelled) {
-                try {
-                    Thread.sleep(500)
-                }
-                catch(ie: InterruptedException) {
-                    //may happen or not, doesn't matter
-                    break
-                }
-            }
-            holder.v = true
-            latch.release()
-        }
-
-        assertFalse(task.isCancelled)
-        task.cancel(true)
-        assertTrue(task.isCancelled)
-        latch.await()
-        assertTrue(holder.v)
-    }
 }

--- a/src/test/kotlin/tornadofx/tests/AsyncTest.kt
+++ b/src/test/kotlin/tornadofx/tests/AsyncTest.kt
@@ -1,5 +1,6 @@
 package tornadofx.tests
 
+import javafx.application.Platform
 import javafx.scene.control.Button
 import javafx.scene.layout.BorderPane
 import javafx.scene.layout.Pane
@@ -86,5 +87,31 @@ class AsyncTest {
         latch.release()
         assertFalse(button.disabledProperty().value)
         assertFalse(latch.locked)
+    }
+
+    @Test
+    fun taskCancel() {
+        val latch = Latch()
+        val holder = object { var v = false }
+
+        val task = runAsync {
+            while(!this.isCancelled) {
+                try {
+                    Thread.sleep(500)
+                }
+                catch(ie: InterruptedException) {
+                    //may happen or not, doesn't matter
+                    break
+                }
+            }
+            holder.v = true
+            latch.release()
+        }
+
+        assertFalse(task.isCancelled)
+        task.cancel(true)
+        assertTrue(task.isCancelled)
+        latch.await()
+        assertTrue(holder.v)
     }
 }

--- a/src/test/kotlin/tornadofx/tests/AsyncTest.kt
+++ b/src/test/kotlin/tornadofx/tests/AsyncTest.kt
@@ -1,6 +1,5 @@
 package tornadofx.tests
 
-import javafx.application.Platform
 import javafx.scene.control.Button
 import javafx.scene.layout.BorderPane
 import javafx.scene.layout.Pane


### PR DESCRIPTION
That `dummyUncaughtExceptionHandler` may not look pretty, but at least it lets us avoid a NPE if no exception handler is set (and usually it's not...)

Fixed some ugliness in FXTask - now it's cleaner and safer (`completedProperty` is now truly immutable).

Added a test for task cancelling.