### PR TITLE
Fixes #495 and more tests

### DIFF
--- a/src/main/java/tornadofx/Collections.kt
+++ b/src/main/java/tornadofx/Collections.kt
@@ -51,8 +51,8 @@ fun <T> MutableList<T>.moveAll(newIndex: Int, predicate: (T) -> Boolean) {
  */
 fun <T> MutableList<T>.moveUpAt(index: Int) {
     if (index == 0) return
-    if (index !in 0 until size) throw Exception("Invalid index $index for MutableList of size $size")
-    val newIndex = index + 1
+    check(index in indices, { "Invalid index $index for MutableList of size $size" })
+    val newIndex = index - 1
     val item = this[index]
     removeAt(index)
     add(newIndex, item)
@@ -64,8 +64,8 @@ fun <T> MutableList<T>.moveUpAt(index: Int) {
  */
 fun <T> MutableList<T>.moveDownAt(index: Int) {
     if (index == size - 1) return
-    if (index !in indices) throw Exception("Invalid index $index for MutableList of size $size")
-    val newIndex = index - 1
+    check(index in indices, { "Invalid index $index for MutableList of size $size" })
+    val newIndex = index + 1
     val item = this[index]
     removeAt(index)
     add(newIndex, item)

--- a/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
+++ b/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
@@ -1,65 +1,70 @@
 package tornadofx.tests
 
+import org.junit.Test
+import tornadofx.move
+import tornadofx.moveAt
+import kotlin.test.assertEquals
+
 class CollectionsTest {
 
-//    @Test
-//    fun testMoveWithValidIndex() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//
-//        list.move(2, 3)
-//
-//        assertEquals(mutableListOf(1, 3, 4, 2), list)
-//    }
-//
-//    @Test
-//    fun testMoveWithInvalidIndex() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//
-//        try {
-//            list.move(2, 102)
-//        } catch (e: Exception) {
-//            assert(e is IllegalStateException)
-//        }
-//    }
-//
-//    @Test
-//    fun testMoveWithInvalidItem() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//
-//        list.move(10, 1)
-//
-//        assertEquals(mutableListOf(1, 2, 3, 4), list)
-//    }
-//
-//    @Test
-//    fun testMoveAtForward() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//        val newIndex = 2
-//
-//        list.moveAt(0, newIndex)
-//
-//        assertEquals(1, list[newIndex])
-//    }
-//
-//    @Test
-//    fun testMoveAtBackward() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//        val newIndex = 0
-//
-//        list.moveAt(2, newIndex)
-//
-//        assertEquals(3, list[newIndex])
-//    }
-//
-//    @Test
-//    fun testMoveAtWithInvalidNewIndex() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//        val newIndex = 10
-//
-//        try {
-//            list.moveAt(2, newIndex)
-//        } catch (e: Exception) {
-//            assert(e is IllegalStateException)
-//        }
-//    }
+    @Test
+    fun testMoveWithValidIndex() {
+        val list = mutableListOf(1, 2, 3, 4)
+
+        list.move(2, 3)
+
+        assertEquals(mutableListOf(1, 3, 4, 2), list)
+    }
+
+    @Test
+    fun testMoveWithInvalidIndex() {
+        val list = mutableListOf(1, 2, 3, 4)
+
+        try {
+            list.move(2, 102)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+
+    @Test
+    fun testMoveWithInvalidItem() {
+        val list = mutableListOf(1, 2, 3, 4)
+
+        list.move(10, 1)
+
+        assertEquals(mutableListOf(1, 2, 3, 4), list)
+    }
+
+    @Test
+    fun testMoveAtForward() {
+        val list = mutableListOf(1, 2, 3, 4)
+        val newIndex = 2
+
+        list.moveAt(0, newIndex)
+
+        assertEquals(1, list[newIndex])
+    }
+
+    @Test
+    fun testMoveAtBackward() {
+        val list = mutableListOf(1, 2, 3, 4)
+        val newIndex = 0
+
+        list.moveAt(2, newIndex)
+
+        assertEquals(3, list[newIndex])
+    }
+
+    @Test
+    fun testMoveAtWithInvalidNewIndex() {
+        val list = mutableListOf(1, 2, 3, 4)
+        val newIndex = 10
+
+        try {
+            list.moveAt(2, newIndex)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
 }

--- a/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
+++ b/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
@@ -2,6 +2,7 @@ package tornadofx.tests
 
 import org.junit.Test
 import tornadofx.move
+import tornadofx.moveAll
 import tornadofx.moveAt
 import kotlin.test.assertEquals
 
@@ -67,4 +68,27 @@ class CollectionsTest {
             assert(e is IllegalStateException)
         }
     }
+
+
+    @Test
+    fun testMoveAllValidIndex() {
+        val list = mutableListOf(1, 2, 3, 4, 5)
+
+        list.moveAll(2, { it < 3 })
+
+        assertEquals(mutableListOf(3, 4, 1, 2, 5), list)
+    }
+
+    @Test
+    fun testMoveAllInvalidIndex() {
+        val list = mutableListOf(1, 2, 3, 4, 5)
+
+        try {
+            list.moveAll(101, { it < 3 })
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+
+
 }

--- a/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
+++ b/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
@@ -1,9 +1,7 @@
 package tornadofx.tests
 
 import org.junit.Test
-import tornadofx.move
-import tornadofx.moveAll
-import tornadofx.moveAt
+import tornadofx.*
 import kotlin.test.assertEquals
 
 class CollectionsTest {
@@ -90,5 +88,43 @@ class CollectionsTest {
         }
     }
 
+    @Test
+    fun testMoveUpAtValidIndex() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
 
+        list.moveUpAt(2)
+
+        assertEquals(listOf(0, 2, 1, 3, 4), list)
+    }
+
+    @Test
+    fun testMoveUpAtInvalidIndex() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        try {
+            list.moveUpAt(10)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+
+    @Test
+    fun testMoveDownAtValidIndex() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        list.moveDownAt(2)
+
+        assertEquals(listOf(0, 1, 3, 2, 4), list)
+    }
+
+    @Test
+    fun testMoveDownAtInvalidIndex() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        try {
+            list.moveDownAt(10)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
 }


### PR DESCRIPTION
Fixes #495 as discussed.

I activated the CollectionsTest tests (they were commented out).

I also used Preconditions.check for checking the index is valid to throw IllegalStateException (as the other functions).

Added tests for moveAll function.