### PR TITLE
Make Spinners commit on loss of focus

### DIFF
--- a/src/main/java/tornadofx/ItemControls.kt
+++ b/src/main/java/tornadofx/ItemControls.kt
@@ -58,6 +58,10 @@ fun <T> EventTarget.spinner(editable: Boolean = false, property: Property<T>? = 
         }
     }
 
+    if (editable) {
+        spinner.focusedProperty().addListener { observable, oldValue, newValue -> if(!newValue) {spinner.increment(0) }}
+    }
+
     return spinner
 }
 
@@ -83,6 +87,10 @@ inline fun <reified T : Number> EventTarget.spinner(min: T? = null, max: T? = nu
         }
     }
 
+    if (editable) {
+        spinner.focusedProperty().addListener { observable, oldValue, newValue -> if(!newValue) {spinner.increment(0) }}
+    }
+
     return opcr(this, spinner, op)
 }
 
@@ -101,6 +109,10 @@ fun <T> EventTarget.spinner(items: ObservableList<T>, editable: Boolean = false,
         }
     }
 
+    if (editable) {
+        spinner.focusedProperty().addListener { observable, oldValue, newValue -> if(!newValue) {spinner.increment(0) }}
+    }
+
     return opcr(this, spinner, op)
 }
 
@@ -117,6 +129,10 @@ fun <T> EventTarget.spinner(valueFactory: SpinnerValueFactory<T>, editable: Bool
             if (event.deltaY > 0) spinner.increment()
             if (event.deltaY < 0) spinner.decrement()
         }
+    }
+
+    if (editable) {
+        spinner.focusedProperty().addListener { observable, oldValue, newValue -> if(!newValue) {spinner.increment(0) }}
     }
 
     return opcr(this, spinner, op)

--- a/src/main/java/tornadofx/ItemControls.kt
+++ b/src/main/java/tornadofx/ItemControls.kt
@@ -59,7 +59,7 @@ fun <T> EventTarget.spinner(editable: Boolean = false, property: Property<T>? = 
     }
 
     if (editable) {
-        spinner.focusedProperty().addListener { observable, oldValue, newValue -> if(!newValue) {spinner.increment(0) }}
+        spinner.focusedProperty().addListener { _, _, newValue -> if(!newValue) {spinner.increment(0) }}
     }
 
     return spinner
@@ -88,7 +88,7 @@ inline fun <reified T : Number> EventTarget.spinner(min: T? = null, max: T? = nu
     }
 
     if (editable) {
-        spinner.focusedProperty().addListener { observable, oldValue, newValue -> if(!newValue) {spinner.increment(0) }}
+        spinner.focusedProperty().addListener { _, _, newValue -> if(!newValue) {spinner.increment(0) }}
     }
 
     return opcr(this, spinner, op)
@@ -110,7 +110,7 @@ fun <T> EventTarget.spinner(items: ObservableList<T>, editable: Boolean = false,
     }
 
     if (editable) {
-        spinner.focusedProperty().addListener { observable, oldValue, newValue -> if(!newValue) {spinner.increment(0) }}
+        spinner.focusedProperty().addListener { _, _, newValue -> if(!newValue) {spinner.increment(0) }}
     }
 
     return opcr(this, spinner, op)
@@ -132,7 +132,7 @@ fun <T> EventTarget.spinner(valueFactory: SpinnerValueFactory<T>, editable: Bool
     }
 
     if (editable) {
-        spinner.focusedProperty().addListener { observable, oldValue, newValue -> if(!newValue) {spinner.increment(0) }}
+        spinner.focusedProperty().addListener { _, _, newValue -> if(!newValue) {spinner.increment(0) }}
     }
 
     return opcr(this, spinner, op)


### PR DESCRIPTION
This change is an attempt to fix the design flaw in Spinner that requires edits to be committed by pressing Enter (and no other way).

The technique comes from this answer in Stack Overflow, and seems to work well. https://stackoverflow.com/a/39380146