### PR TITLE
Eliminate interactions between tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,21 @@
                     </execution>
                 </executions>
             </plugin>
-        </plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.20.1</version>
+				<configuration>
+					<!--<parallel>classes</parallel>-->
+					<forkCount>1</forkCount>
+					<reuseForks>false</reuseForks>
+					<includes>
+						<include>**/tests/*Test.kt</include>
+					</includes>
+				</configuration>
+			</plugin>
+
+		</plugins>
     </build>
 
     <pluginRepositories>

--- a/src/test/kotlin/tornadofx/tests/ChildInterceptorTest.kt
+++ b/src/test/kotlin/tornadofx/tests/ChildInterceptorTest.kt
@@ -4,6 +4,7 @@ import javafx.event.EventTarget
 import javafx.scene.Node
 import javafx.scene.layout.Pane
 import javafx.stage.Stage
+import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
 import org.testfx.api.FxToolkit
@@ -11,64 +12,71 @@ import tornadofx.*
 import kotlin.test.assertEquals
 
 abstract class BaseInterceptor : ChildInterceptor {
-    var intercepted: Boolean = false
+	var intercepted: Boolean = false
 }
 
 class DummyPane : Pane()
 
 fun EventTarget.dummyPane(op: DummyPane.() -> Unit = {}): DummyPane {
-    return opcr(this,DummyPane(),op)
+	return opcr(this, DummyPane(), op)
 }
 
 class FirstInterceptor : BaseInterceptor() {
-    override fun invoke(parent: EventTarget, node: Node, index: Int?): Boolean = when (parent) {
-        is DummyPane -> {
-            intercepted = true
-            true
-        }
-        else -> false
-    }
+	override fun invoke(parent: EventTarget, node: Node, index: Int?): Boolean = when (parent) {
+		is DummyPane -> {
+			intercepted = true
+			true
+		}
+		else -> false
+	}
 }
 
 class SecondInterceptor : BaseInterceptor() {
-    override fun invoke(parent: EventTarget, node: Node, index: Int?): Boolean = when (parent) {
-        is DummyPane -> {
-            intercepted = true
-            true
-        }
-        else -> false
-    }
+	override fun invoke(parent: EventTarget, node: Node, index: Int?): Boolean = when (parent) {
+		is DummyPane -> {
+			intercepted = true
+			true
+		}
+		else -> false
+	}
 }
 
 class MyTestView : View("TestView") {
-    override val root = dummyPane {
-        button {}
-    }
+	override val root = dummyPane {
+		button {}
+	}
 }
 
 class ChildInterceptorTest {
 
-    companion object {
+	companion object {
+		val app = App(MyTestView::class)
 
-        @JvmStatic
-        @BeforeClass
-        fun before() {
-            val primaryStage: Stage = FxToolkit.registerPrimaryStage()
-            val app = App(MyTestView::class)
-            FX.registerApplication(FxToolkit.setupApplication {
-                app
-            }, primaryStage)
-        }
-    }
+		@JvmStatic
+		@BeforeClass
+		fun before() {
+			val primaryStage: Stage = FxToolkit.registerPrimaryStage()
+			FX.registerApplication(FxToolkit.setupApplication {
+				app
+			}, primaryStage)
+		}
 
-    @Test
-    fun interceptorsLoaded() {
-        assertEquals(FX.childInterceptors.size, 2)
-    }
+		@JvmStatic
+		@AfterClass
+		fun after() {
+			FxToolkit.cleanupApplication(app)
+		}
+	}
+
+	@Test
+	fun interceptorsLoaded() {
+		assertEquals(FX.childInterceptors.size, 2)
+	}
 
 
-    @Test
-    fun onlyOneInterceptorShouldWork() {
-        assertEquals(FX.childInterceptors.map { it as BaseInterceptor }.filter { it.intercepted }.size, 1)
-    }
+	@Test
+	fun onlyOneInterceptorShouldWork() {
+		assertEquals(FX.childInterceptors.map { it as BaseInterceptor }.filter { it.intercepted }.size,
+				1)
+	}
 }

--- a/src/test/kotlin/tornadofx/tests/StylesheetErrorTest.kt
+++ b/src/test/kotlin/tornadofx/tests/StylesheetErrorTest.kt
@@ -1,24 +1,44 @@
 package tornadofx.tests
 
 import javafx.stage.Stage
+import org.junit.AfterClass
+import org.junit.BeforeClass
 import org.junit.Test
 import org.testfx.api.FxAssert.verifyThat
-import org.testfx.framework.junit.ApplicationTest
+import org.testfx.api.FxToolkit
 import org.testfx.matcher.control.LabeledMatchers.hasText
-import tornadofx.testapps.StylesheetErrorTest
+import tornadofx.*
+import tornadofx.testapps.Styles
+import tornadofx.testapps.StylesheetErrorView
 
-class StylesheetErrorTest : ApplicationTest() {
+//@Ignore
+class StylesheetErrorTest {
 
-    /**
-     * This will cause a stylesheet error, but should not crash the application.
-     */
-    override fun start(stage: Stage) {
-        StylesheetErrorTest().start(stage)
-    }
+	companion object {
 
-    @Test
-    fun shouldStartApplicationWithWrongStylesheetWithoutCrashing() {
-        verifyThat(".my-button", hasText("Click here"))
-    }
+		val app = App(StylesheetErrorView::class, Styles::class)
+		@JvmStatic
+		@BeforeClass
+		fun before() {
+			val primaryStage: Stage = FxToolkit.registerPrimaryStage()
+			/**
+			 * This will cause a stylesheet error, but should not crash the application.
+			 */
+			FX.registerApplication(FxToolkit.setupApplication {
+				app
+			}, primaryStage)
+		}
+
+		@JvmStatic
+		@AfterClass
+		fun after() {
+			FxToolkit.cleanupApplication(app)
+		}
+	}
+
+	@Test
+	fun shouldStartApplicationWithWrongStylesheetWithoutCrashing() {
+		verifyThat(".my-button", hasText("Click here"))
+	}
 
 }


### PR DESCRIPTION
On some systems, the order of test execution could impact tests passing or failing, indicating that state from one test could be carried over to other tests.

This commit does two things to try and avoid that situation.

1. Sets up the Maven Surefire plugin to run classes in separate forks (JVMs).

2. Refactor the two problematic tests to use the same approach for setting up and tearing down the FX environment they run in.

On my macOS system all tests now pass when running from Maven and also when running directly in IDEA.