### PR TITLE
ItemViewModel.item nullable instead of ambiguous platform type.

### DIFF
--- a/src/main/java/tornadofx/Async.kt
+++ b/src/main/java/tornadofx/Async.kt
@@ -455,9 +455,9 @@ class FXTask<T>(val status: TaskStatus? = null, val func: FXTask<*>.() -> T) : T
 }
 
 open class TaskStatus : ItemViewModel<FXTask<*>>() {
-    val running: ReadOnlyBooleanProperty = bind { SimpleBooleanProperty().apply { if (item != null) bind(item.runningProperty()) } }
-    val completed: ReadOnlyBooleanProperty = bind { SimpleBooleanProperty().apply { if (item != null) bind(item.completedProperty) } }
-    val message: ReadOnlyStringProperty = bind { SimpleStringProperty().apply { if (item != null) bind(item.messageProperty()) } }
-    val title: ReadOnlyStringProperty = bind { SimpleStringProperty().apply { if (item != null) bind(item.titleProperty()) } }
-    val progress: ReadOnlyDoubleProperty = bind { SimpleDoubleProperty().apply { if (item != null) bind(item.progressProperty()) } }
+    val running: ReadOnlyBooleanProperty = bind { SimpleBooleanProperty().apply { if (item != null) bind(item!!.runningProperty()) } }
+    val completed: ReadOnlyBooleanProperty = bind { SimpleBooleanProperty().apply { if (item != null) bind(item!!.completedProperty) } }
+    val message: ReadOnlyStringProperty = bind { SimpleStringProperty().apply { if (item != null) bind(item!!.messageProperty()) } }
+    val title: ReadOnlyStringProperty = bind { SimpleStringProperty().apply { if (item != null) bind(item!!.titleProperty()) } }
+    val progress: ReadOnlyDoubleProperty = bind { SimpleDoubleProperty().apply { if (item != null) bind(item!!.progressProperty()) } }
 }

--- a/src/main/java/tornadofx/ViewModel.kt
+++ b/src/main/java/tornadofx/ViewModel.kt
@@ -511,7 +511,7 @@ val ObservableValue<*>.viewModelFacade: Property<*>? get() = ViewModel.getFacade
 
 @Suppress("UNCHECKED_CAST")
 open class ItemViewModel<T> @JvmOverloads constructor(initialValue: T? = null, val itemProperty: ObjectProperty<T> = SimpleObjectProperty(initialValue)) : ViewModel() {
-    var item by itemProperty
+    var item: T? by itemProperty
 
     val empty = itemProperty.isNull
     val isEmpty: Boolean get() = empty.value


### PR DESCRIPTION
At the moment the `item` field of ItemViewModel uses the platform type with uncertain nullability. This can result in NPEs since the user is not aware that this value can be `null` and the compiler does not care about that for platform types.