### PR TITLE
Added ResourceBundle.format function to insert formatted strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Node.index will tell you the Node's index in the parent container
 - placeholder<UIComponent> builder for TableView, TreeTableView, ListView  
 - obserableList<T>() creates FXCollections.observableArrayList<T>
+- ResourceBundle.format() provides a short way to insert translations with variables in them
 
 ## [1.7.14]
 

--- a/src/main/java/tornadofx/Messages.kt
+++ b/src/main/java/tornadofx/Messages.kt
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets
 import java.security.AccessController
 import java.security.PrivilegedActionException
 import java.security.PrivilegedExceptionAction
+import java.text.MessageFormat
 import java.util.*
 
 private fun <EXCEPTION: Throwable, RETURN> doPrivileged(privilegedAction: ()->RETURN) : RETURN = try {
@@ -52,6 +53,12 @@ object FXResourceBundleControl : ResourceBundle.Control() {
  * Convenience function to support lookup via messages["key"]
  */
 operator fun ResourceBundle.get(key: String) = getString(key)
+
+/**
+ * Convenience function to retrieve a translation and format it with values.
+ */
+fun ResourceBundle.format(key: String, vararg fields: Any) =
+        MessageFormat(this[key], locale).format(fields)
 
 class FXPropertyResourceBundle(input: InputStreamReader): PropertyResourceBundle(input) {
     fun inheritFromGlobal() {


### PR DESCRIPTION
Allows to quickly insert translation strings that contain placeholders as specified in https://docs.oracle.com/javase/tutorial/i18n/format/messageFormat.html.