### PR TITLE
Add test case for multiple lifecycle async app bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             <version>${de.jensd.fontawesomefx.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk</artifactId>
+            <version>1.7</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/test/kotlin/tornadofx/testapps/MultipleLifecycleAsyncApp.kt
+++ b/src/test/kotlin/tornadofx/testapps/MultipleLifecycleAsyncApp.kt
@@ -1,0 +1,25 @@
+package tornadofx.testapps
+
+import tornadofx.*
+
+class MultipleLifecycleAsyncApp : App(MainView::class)
+
+class MainView : View("Multiple Lifecycle Async") {
+    val controller: MainController by inject()
+    override val root = pane {
+        button("Robot-click to repeat bug") {
+            id = "bug"
+            action {
+                runAsync {
+                    controller.onAction("button clicked")
+                }
+            }
+        }
+    }
+}
+
+class MainController : Controller() {
+    fun onAction(message: String) {
+        println(message)
+    }
+}

--- a/src/test/kotlin/tornadofx/testapps/MultipleLifecycleAsyncApp.kt
+++ b/src/test/kotlin/tornadofx/testapps/MultipleLifecycleAsyncApp.kt
@@ -2,10 +2,10 @@ package tornadofx.testapps
 
 import tornadofx.*
 
-class MultipleLifecycleAsyncApp : App(MainView::class)
+class MultipleLifecycleAsyncApp : App(MultipleLifecycleAsyncView::class)
 
-class MainView : View("Multiple Lifecycle Async") {
-    val controller: MainController by inject()
+class MultipleLifecycleAsyncView : View("Multiple Lifecycle Async") {
+    val controller: MultipleLifecycleAsyncController by inject()
     override val root = pane {
         button("Robot-click to repeat bug") {
             id = "bug"
@@ -18,7 +18,7 @@ class MainView : View("Multiple Lifecycle Async") {
     }
 }
 
-class MainController : Controller() {
+class MultipleLifecycleAsyncController : Controller() {
     fun onAction(message: String) {
         println(message)
     }

--- a/src/test/kotlin/tornadofx/tests/MultipleLifecycleAsyncAppTest.kt
+++ b/src/test/kotlin/tornadofx/tests/MultipleLifecycleAsyncAppTest.kt
@@ -14,8 +14,8 @@ import org.junit.runners.Parameterized
 import org.testfx.api.FxRobot
 import org.testfx.api.FxToolkit
 import tornadofx.*
-import tornadofx.testapps.MainController
 import tornadofx.testapps.MultipleLifecycleAsyncApp
+import tornadofx.testapps.MultipleLifecycleAsyncController
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -35,7 +35,7 @@ class AsyncBugAppTest(val rounds: Int) {
     lateinit var app: App
 
     @RelaxedMockK
-    lateinit var controller: MainController
+    lateinit var controller: MultipleLifecycleAsyncController
 
     @Rule
     @JvmField

--- a/src/test/kotlin/tornadofx/tests/MultipleLifecycleAsyncAppTest.kt
+++ b/src/test/kotlin/tornadofx/tests/MultipleLifecycleAsyncAppTest.kt
@@ -1,0 +1,77 @@
+package tornadofx.tests
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.Timeout
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.testfx.api.FxRobot
+import org.testfx.api.FxToolkit
+import tornadofx.*
+import tornadofx.testapps.MainController
+import tornadofx.testapps.MultipleLifecycleAsyncApp
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+
+@RunWith(Parameterized::class)
+class AsyncBugAppTest(val rounds: Int) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Int>> {
+            return listOf(arrayOf(1), arrayOf(1))
+        }
+    }
+
+    lateinit var robot: FxRobot
+    lateinit var app: App
+
+    @RelaxedMockK
+    lateinit var controller: MainController
+
+    @Rule
+    @JvmField
+    val timeout = Timeout(10, TimeUnit.SECONDS)
+
+    @Before
+    fun before() {
+        MockKAnnotations.init(this)
+
+        FxToolkit.registerPrimaryStage()
+        app = MultipleLifecycleAsyncApp()
+        app.scope.set(controller)
+        FxToolkit.setupApplication { app }
+        robot = FxRobot()
+
+        println("rounds = $rounds")
+    }
+
+    @After
+    fun after() {
+        FxToolkit.cleanupStages()
+        FxToolkit.cleanupApplication(app)
+    }
+
+    @Test()
+    fun itShouldSurviveRunAsyncMultipleTimes() {
+        val latch = CountDownLatch(rounds)
+        every { controller.onAction(any()) }.answers { latch.countDown() }
+
+        var i = 0
+        while (i < rounds) {
+            robot.clickOn("#bug")
+            i++
+        }
+
+        latch.await()
+        verify(exactly = rounds) { controller.onAction(any()) }
+    }
+}


### PR DESCRIPTION
@edvin already committed a fix for this issue I had posted about at https://stackoverflow.com/questions/48512919/java-util-concurrent-rejectedexecutionexception-when-action-calls-runasync

I ran this test against a snapshot with his change and confirmed the issue is fixed