### PR TITLE
Remove maven surefire configuration preventing tests from running

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,21 +264,13 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.20.1</version>
-				<configuration>
-					<!--<parallel>classes</parallel>-->
-					<forkCount>1</forkCount>
-					<reuseForks>false</reuseForks>
-					<includes>
-						<include>**/tests/*Test.kt</include>
-					</includes>
-				</configuration>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20.1</version>
+            </plugin>
 
-		</plugins>
+        </plugins>
     </build>
 
     <pluginRepositories>


### PR DESCRIPTION
Surefire is now executing tests on my machine. Only one test is failing:
ChildInterceptorTest.

Opening this PR prior to fixing the one failing test to solicit feedback on the `pom.xml` change.