### PR TITLE
Update jdk9 branch to current master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,90 @@
 # Change Log
 
-## [1.7.12-SNAPSHOT]
+## [1.7.15-SNAPSHOT]
+
+### Fixed
+
+- UIComponent.close() should be able to close primary stage as well (https://github.com/edvin/tornadofx/issues/622)
+- SmartResize.Policy manual resize broken (https://github.com/edvin/tornadofx/issues/570)
+- TableView bound to ListProperty should rebind when value changes
+- Allow calling Workspace.disableNavigation() when workspace is empty
+- Thread pools are reinitialized on App.start() to support stop/start multiple times within the same JVM
+- ServiceLoader provided interceptors were added every time an App class was initialized 
+- inheritParamHolder and inheritScopeHolder are cleared on Application stop (https://github.com/edvin/tornadofx/issues/602)
+- smartResize throws exception for hidden columns (https://github.com/edvin/tornadofx/issues/606)
+
+### Changes
+
+- Kotlin 1.2.21
+- AnchorPaneConstraint properties now accept any Number, not just Double
+- AbstractField.textProperty was renamed to labelProperty to avoid confusion with the textProperty() exposed by textfields inside of a field
+- ItemViewModel.bind `defaultValue` parameter
+- Node builders inside of `MenuItem` will automatically assign the node to the `graphic` property of the menu item
+- The App class (main application entrypoint) no longer requires a primary view parameter, in case you want to show a tray icon or determinine what view to show some other way
+- Renamed tableview column builder for readonly non-observable properties to `readonlyColumn` (https://github.com/edvin/tornadofx/issues/599)
+- Renamed Node.index to Node.indexInParent to avoid subtle bugs (Partly fixes https://github.com/edvin/tornadofx/issues/598)
+- Removed CheckBoxCell in favor of inline cellFormat
+
+### Additions
+
+- StackPane.connectWorkspaceActions() along with StackPane.contentProperty and various Workspace related functions and properties (https://github.com/edvin/tornadofx/issues/604)
+- TextInputControl.filterInput allows you to discriminate what kind of input should be accepted for a text input control
+- String.isLong(), isInt(), isDouble() and isFloat()
+- checkmenuitem builder accepts string for keycombination and selected property
+- Node.index will tell you the Node's index in the parent container
+- placeholder<UIComponent> builder for TableView, TreeTableView, ListView  
+- obserableList<T>() creates FXCollections.observableArrayList<T>
+- ResourceBundle.format() provides a short way to insert translations with variables in them
+
+## [1.7.14]
+
+### Fixed
+
+- `runAsync` would skip the success/fail steps if no work was done in the op block 
+- TableView Pojo Column references support boolean "is" style properties (https://github.com/edvin/tornadofx/issues/560)
+- TabPane.tab<UIComponent> inside of an UIComponent is now scope aware
+- TreeView.lazyPopulate should never assign null list if filter results in no items
+
+### Changes
+
+- Kotlin 1.2.10
+- Node builders inside of `ButtonBase` will automatically assign the node to the `graphic` property of the Button
+
+### Additions
+
+- ConfigProperties (`config`) is now `Closable` so it can be used with `use`
+
+## [1.7.13]
+
+### Fixed
+
+- Navigation button issue when already docked view was docked again (https://github.com/edvin/tornadofx/issues/526)
+- Internal thread pools are shutdown on app exit. Running threads in the default thread pool will still block application stop.
+- ComboBox.makeAutoCompletable() inspects listView.prefWidth for being bound before attemting to set it (https://github.com/edvin/tornadofx/issues/530)
+- Wizard.canGoBack override caused NPE (https://github.com/edvin/tornadofx/issues/211)
+
+### Changes
+- Kotlin 1.2.0
+- ItemViewModel.bindTo(itemFragment) supports all itemb fragments now, not just ListCellFragment
+- lambda's that return unit are no longer nullable. use the default-lambda instead
+- ChildInterceptor is now an Interface.
+- Component.messages are fetched using the classloader that defined the Component subclass (https://github.com/edvin/tornadofx/issues/553)
+
+### Additions
+
+- `cellFragment` support for DataGrid
+- ObservableValue<String>.isBlank() and ObservableValue<String>.isNotBlank() which returns BooleanBinding. Useful for binding to TextField enabled/visible state
+- Added `owner` and `title` parameters to `alert` and other dialog builders (https://github.com/edvin/tornadofx/issues/522)
+- TextInputControl.editableWhen
+- `multiSelect()` for TreeView, TreeTableView, TableView and ListView
+- Stylesheets can now be added specificly to a `Parent`- Node with `addStylesheet`
+
+## [1.7.12]
 
 ### Fixed
 - Fixed #434 leaf nodes are now getting set as expected for `lazypopulate`.
 - Style builder can be applied to PopupControl, Tab, TableColumnBase (https://github.com/edvin/tornadofx/issues/476)
+- Better handling of Column.makeEditable() for properties that implement Property<Number>
 
 ### Changes
 - Refactoring: Moved all extension functions and properties targeting `TreeView`
@@ -12,6 +92,16 @@
 - `alert` builder accepts optional owner parameter (https://github.com/edvin/tornadofx/issues/483)
 
 ### Additions
+- `fitToParentHeight/Width/Size` as well as `fitToHeight/Width/Size(region)` helpers (https://github.com/edvin/tornadofx/pull/519)
+- `beforeShutdown` allows you to register shutdown hooks
+- `DataGridPaginator` component to help with pagination for `DataGrid`
+- runAsync supports `daemon` parameter to control thread characteristics (https://github.com/edvin/tornadofx/pull/508)
+- Node.`runAsyncWithOverlay`
+- `Latch`, a subclass of CountdownLatch that exposes a `lockedProperty` and provides immediate release ability
+- Inline type safe stylesheet on Parent using the `stylesheet` builder
+- Tab.close()
+- JsonBuilder.add() supports Iterable<Any> (Turned into JsonArray)
+- Added `customitem` menu item builder (https://github.com/edvin/tornadofx/pull/488)
 - The default lefCheck for `lazypopulate` is now also recognizing an empty list as a leaf.
 - menubutton builder (https://github.com/edvin/tornadofx/issues/461)
 - MenuButton.item builder

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ You also need a full rebuild of your code after a version upgrade. If you run in
 - [KDocs](https://tornadofx.io/dokka/tornadofx/tornadofx/index.html)
 - [Wiki](https://github.com/edvin/tornadofx/wiki)
 - [Slack](https://kotlinlang.slack.com/messages/tornadofx/details/)
-- [User Forum](https://groups.google.com/forum/#!forum/tornadofx)
-- [Dev Forum](https://groups.google.com/forum/#!forum/tornadofx-dev)
 - [Stack Overflow](http://stackoverflow.com/questions/ask?tags=tornadofx)
 - [Documentation](https://github.com/edvin/tornadofx/wiki/Documentation) 
 - [IntelliJ IDEA Plugin](https://github.com/edvin/tornadofx-idea-plugin) 
@@ -70,7 +68,7 @@ You also need a full rebuild of your code after a version upgrade. If you run in
 ```bash
 mvn archetype:generate -DarchetypeGroupId=no.tornado \
   -DarchetypeArtifactId=tornadofx-quickstart-archetype \
-  -DarchetypeVersion=1.7.11
+  -DarchetypeVersion=1.7.14
 ```
 
 ### Add TornadoFX to your project
@@ -81,14 +79,14 @@ mvn archetype:generate -DarchetypeGroupId=no.tornado \
 <dependency>
     <groupId>no.tornado</groupId>
     <artifactId>tornadofx</artifactId>
-    <version>1.7.11</version>
+    <version>1.7.14</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-compile 'no.tornado:tornadofx:1.7.11'
+compile 'no.tornado:tornadofx:1.7.14'
 ```
 
 ### Snapshots are published to Sonatype

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jre8</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
@@ -68,6 +68,12 @@
             <groupId>de.jensd</groupId>
             <artifactId>fontawesomefx</artifactId>
             <version>${fontawesomefx.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk</artifactId>
+            <version>1.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -177,91 +183,105 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--<plugin>-->
-                <!--<groupId>org.jetbrains.dokka</groupId>-->
-                <!--<artifactId>dokka-maven-plugin</artifactId>-->
-                <!--<version>${dokka.version}</version>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<phase>pre-site</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>dokka</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-source-plugin</artifactId>-->
-                <!--<version>${maven.source.version}</version>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<phase>compile</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>aggregate</goal>-->
-                            <!--<goal>jar</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<artifactId>maven-jar-plugin</artifactId>-->
-                <!--<version>${maven.jar.version}</version>-->
-                <!--<configuration>-->
-                    <!--<archive>-->
-                        <!--<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>-->
-                    <!--</archive>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-javadoc-plugin</artifactId>-->
-                <!--<version>${maven.javadoc.version}</version>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<phase>compile</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>javadoc</goal>-->
-                            <!--<goal>jar</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.felix</groupId>-->
-                <!--<artifactId>maven-bundle-plugin</artifactId>-->
-                <!--<version>${maven.bundle.version}</version>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>bundle-manifest</id>-->
-                        <!--<phase>process-classes</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>manifest</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-                <!--<configuration>-->
-                    <!--<instructions>-->
-                        <!--<Bundle-Activator>tornadofx.osgi.impl.Activator</Bundle-Activator>-->
-                        <!--<Bundle-SymbolicName>no.tornado.tornadofx</Bundle-SymbolicName>-->
-                    <!--</instructions>-->
-                <!--</configuration>-->
-            <!--</plugin>-->
-            <!--<plugin>-->
-                <!--<groupId>org.apache.maven.plugins</groupId>-->
-                <!--<artifactId>maven-gpg-plugin</artifactId>-->
-                <!--<version>${maven.gpg.version}</version>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>sign-artifacts</id>-->
-                        <!--<phase>deploy</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>sign</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
-        </plugins>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>${dokka.version}</version>
+                <executions>
+                    <execution>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>dokka</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>aggregate</goal>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.version}</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>javadoc</goal>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.version}</version>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Activator>tornadofx.osgi.impl.Activator</Bundle-Activator>
+                        <Bundle-SymbolicName>no.tornado.tornadofx</Bundle-SymbolicName>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven.gpg.version}</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.20.1</version>
+				<configuration>
+					<!--<parallel>classes</parallel>-->
+					<forkCount>1</forkCount>
+					<reuseForks>false</reuseForks>
+					<includes>
+						<include>**/tests/*Test.kt</include>
+					</includes>
+				</configuration>
+			</plugin>
+
+		</plugins>
     </build>
 
     <pluginRepositories>
@@ -273,10 +293,10 @@
     </pluginRepositories>
 
     <properties>
-        <kotlin.version>1.1.51</kotlin.version>
+        <kotlin.version>1.2.21</kotlin.version>
         <dokka.version>0.9.9</dokka.version>
 
-        <javax.json.version>1.0.4</javax.json.version>
+        <javax.json.version>1.1.2</javax.json.version>
         <httpclient.version>4.5.3</httpclient.version>
         <felix.framework.version>5.6.8</felix.framework.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
             <version>${javax.json.version}</version>
         </dependency>
         <dependency>
@@ -298,7 +298,7 @@
 
         <javax.json.version>1.1.2</javax.json.version>
         <httpclient.version>4.5.3</httpclient.version>
-        <felix.framework.version>5.6.8</felix.framework.version>
+        <felix.framework.version>5.6.10</felix.framework.version>
         <junit.version>4.12</junit.version>
         <testfx-core.version>4.0.4-alpha</testfx-core.version>
         <testfx-junit.version>4.0.4-alpha</testfx-junit.version>
@@ -308,8 +308,8 @@
         <maven.compiler.version>3.7.0</maven.compiler.version>
         <maven.source.version>3.0.1</maven.source.version>
         <maven.jar.version>3.0.2</maven.jar.version>
-        <maven.javadoc.version>2.10.4</maven.javadoc.version>
-        <maven.bundle.version>3.3.0</maven.bundle.version>
+        <maven.javadoc.version>3.0.0</maven.javadoc.version>
+        <maven.bundle.version>3.5.0</maven.bundle.version>
         <maven.gpg.version>1.4</maven.gpg.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module tornadofx {
 
     requires java.prefs;
     requires java.desktop;
+    requires java.json;
 
     requires javafx.deploy;
     requires javafx.controls;
@@ -17,9 +18,9 @@ module tornadofx {
     requires static org.apache.felix.framework;
     requires static httpcore;
     requires static httpclient;
-    requires static javax.json;
+    requires kotlin.reflect;
 
     exports tornadofx;
-    exports tornadofx.osgi;
-    exports sun.net.www.protocol.css;
+    //exports tornadofx.osgi;
+    //exports sun.net.www.protocol.css;
 }

--- a/src/main/java/tornadofx/Animation.kt
+++ b/src/main/java/tornadofx/Animation.kt
@@ -15,6 +15,7 @@ import javafx.scene.paint.Paint
 import javafx.scene.shape.Shape
 import javafx.scene.transform.Rotate
 import javafx.util.Duration
+import tornadofx.Stylesheet.Companion.axis
 import java.util.*
 
 operator fun Timeline.plusAssign(keyFrame: KeyFrame) {
@@ -67,7 +68,7 @@ fun timeline(play: Boolean = true, op: (Timeline).() -> Unit): Timeline {
  */
 fun UIComponent.move(time: Duration, destination: Point2D,
                      easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                     op: (TranslateTransition.() -> Unit)? = null)
+                     op: TranslateTransition.() -> Unit = {})
         = root.move(time, destination, easing, reversed, play, op)
 
 /**
@@ -83,7 +84,7 @@ fun UIComponent.move(time: Duration, destination: Point2D,
  */
 fun Node.move(time: Duration, destination: Point2D,
               easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-              op: (TranslateTransition.() -> Unit)? = null): TranslateTransition {
+              op: TranslateTransition.() -> Unit = {}): TranslateTransition {
     val target: Point2D
     if (reversed) {
         target = point(translateX, translateY)
@@ -94,7 +95,7 @@ fun Node.move(time: Duration, destination: Point2D,
     }
     return TranslateTransition(time, this).apply {
         interpolator = easing
-        op?.invoke(this)
+        op(this)
         toX = target.x
         toY = target.y
         if (play) play()
@@ -114,7 +115,7 @@ fun Node.move(time: Duration, destination: Point2D,
  */
 fun UIComponent.rotate(time: Duration, angle: Number,
                        easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                       op: (RotateTransition.() -> Unit)? = null)
+                       op: RotateTransition.() -> Unit = {})
         = root.rotate(time, angle, easing, reversed, play, op)
 
 /**
@@ -130,7 +131,7 @@ fun UIComponent.rotate(time: Duration, angle: Number,
  */
 fun Node.rotate(time: Duration, angle: Number,
                 easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                op: (RotateTransition.() -> Unit)? = null): RotateTransition {
+                op: RotateTransition.() -> Unit = {}): RotateTransition {
     val target: Double
     if (reversed) {
         target = rotate
@@ -140,7 +141,7 @@ fun Node.rotate(time: Duration, angle: Number,
     }
     return RotateTransition(time, this).apply {
         interpolator = easing
-        op?.invoke(this)
+        op(this)
         toAngle = target
         if (play) play()
     }
@@ -159,7 +160,7 @@ fun Node.rotate(time: Duration, angle: Number,
  */
 fun UIComponent.scale(time: Duration, scale: Point2D,
                       easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                      op: (ScaleTransition.() -> Unit)? = null)
+                      op: ScaleTransition.() -> Unit  = {})
         = root.scale(time, scale, easing, reversed, play, op)
 
 /**
@@ -175,7 +176,7 @@ fun UIComponent.scale(time: Duration, scale: Point2D,
  */
 fun Node.scale(time: Duration, scale: Point2D,
                easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-               op: (ScaleTransition.() -> Unit)? = null): ScaleTransition {
+               op: ScaleTransition.() -> Unit = {}): ScaleTransition {
     val target: Point2D
     if (reversed) {
         target = point(scaleX, scaleY)
@@ -186,7 +187,7 @@ fun Node.scale(time: Duration, scale: Point2D,
     }
     return ScaleTransition(time, this).apply {
         interpolator = easing
-        op?.invoke(this)
+        op(this)
         toX = target.x
         toY = target.y
         if (play) play()
@@ -206,7 +207,7 @@ fun Node.scale(time: Duration, scale: Point2D,
  */
 fun UIComponent.fade(time: Duration, opacity: Number,
                      easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                     op: (FadeTransition.() -> Unit)? = null)
+                     op: FadeTransition.() -> Unit = {})
         = root.fade(time, opacity, easing, reversed, play, op)
 
 /**
@@ -222,7 +223,7 @@ fun UIComponent.fade(time: Duration, opacity: Number,
  */
 fun Node.fade(time: Duration, opacity: Number,
               easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-              op: (FadeTransition.() -> Unit)? = null): FadeTransition {
+              op: FadeTransition.() -> Unit = {}): FadeTransition {
     val target: Double
     if (reversed) {
         target = this.opacity
@@ -232,7 +233,7 @@ fun Node.fade(time: Duration, opacity: Number,
     }
     return FadeTransition(time, this).apply {
         interpolator = easing
-        op?.invoke(this)
+        op(this)
         toValue = target
         if (play) play()
     }
@@ -255,7 +256,7 @@ fun Node.fade(time: Duration, opacity: Number,
  */
 fun UIComponent.transform(time: Duration, destination: Point2D, angle: Number, scale: Point2D, opacity: Number,
                           easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                          op: (ParallelTransition.() -> Unit)? = null)
+                          op: ParallelTransition.() -> Unit = {})
         = root.transform(time, destination, angle, scale, opacity, easing, reversed, play, op)
 
 /**
@@ -275,14 +276,14 @@ fun UIComponent.transform(time: Duration, destination: Point2D, angle: Number, s
  */
 fun Node.transform(time: Duration, destination: Point2D, angle: Number, scale: Point2D, opacity: Number,
                    easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                   op: (ParallelTransition.() -> Unit)? = null)
+                   op: ParallelTransition.() -> Unit = {})
         = move(time, destination, easing, reversed, play)
         .and(rotate(time, angle, easing, reversed, play))
         .and(scale(time, scale, easing, reversed, play))
         .and(fade(time, opacity, easing, reversed, play))
         .apply {
             interpolator = easing
-            op?.invoke(this)
+            op(this)
             if (play) play()
         }
 
@@ -294,15 +295,12 @@ fun Node.transform(time: Duration, destination: Point2D, angle: Number, scale: P
  * @param op Modify the animation after it is created
  * @return A ParallelTransition
  */
-fun Animation.and(vararg animation: Animation, op: (ParallelTransition.() -> Unit)? = null) : ParallelTransition {
+fun Animation.and(vararg animation: Animation, op: ParallelTransition.() -> Unit = {}) : ParallelTransition {
     if (this is ParallelTransition) {
         children += animation
-        op?.invoke(this)
-        return this
+        return this.also(op)
     } else {
-        val transition = ParallelTransition(this, *animation)
-        op?.invoke(transition)
-        return transition
+        return ParallelTransition(this, *animation).also(op)
     }
 }
 
@@ -323,9 +321,9 @@ infix fun Animation.and(animation: Animation): ParallelTransition {
  * @param op Modify the animation before playing
  * @return A ParallelTransition
  */
-fun Iterable<Animation>.playParallel(play: Boolean = true, op: (ParallelTransition.() -> Unit)? = null) = ParallelTransition().apply {
+fun Iterable<Animation>.playParallel(play: Boolean = true, op: ParallelTransition.() -> Unit = {}) = ParallelTransition().apply {
     children.setAll(toList())
-    op?.invoke(this)
+    op(this)
     if (play) play()
 }
 
@@ -337,15 +335,12 @@ fun Iterable<Animation>.playParallel(play: Boolean = true, op: (ParallelTransiti
  * @param op Modify the animation after it is created
  * @return A SequentialTransition
  */
-fun Animation.then(vararg animation: Animation, op: (SequentialTransition.() -> Unit)? = null): SequentialTransition {
+fun Animation.then(vararg animation: Animation, op: SequentialTransition.() -> Unit = {}): SequentialTransition {
     if (this is SequentialTransition) {
         children += animation
-        op?.invoke(this)
-        return this
+        return this.also(op)
     } else {
-        val transition = SequentialTransition(this, *animation)
-        op?.invoke(transition)
-        return transition
+        return SequentialTransition(this, *animation).also(op)
     }
 }
 
@@ -366,53 +361,53 @@ infix fun Animation.then(animation: Animation): SequentialTransition {
  * @param op Modify the animation before playing
  * @return A SequentialTransition
  */
-fun Iterable<Animation>.playSequential(play: Boolean = true, op: (SequentialTransition.() -> Unit)? = null) = SequentialTransition().apply {
+fun Iterable<Animation>.playSequential(play: Boolean = true, op: SequentialTransition.() -> Unit = {}) = SequentialTransition().apply {
     children.setAll(toList())
-    op?.invoke(this)
+    op(this)
     if (play) play()
 }
 
 fun Shape.animateFill(time: Duration, from: Color, to: Color,
                       easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                      op: (FillTransition.() -> Unit)? = null): FillTransition {
+                      op: FillTransition.() -> Unit = {}): FillTransition {
     return FillTransition(time, this, from, to).apply {
         interpolator = easing
         if (reversed) {
             fromValue = to
             toValue = from
         }
-        op?.invoke(this)
+        op(this)
         if (play) play()
     }
 }
 
 fun Shape.animateStroke(time: Duration, from: Color, to: Color,
                         easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                        op: (StrokeTransition.() -> Unit)? = null): StrokeTransition {
+                        op: StrokeTransition.() -> Unit = {}): StrokeTransition {
     return StrokeTransition(time, this, from, to).apply {
         interpolator = easing
         if (reversed) {
             fromValue = to
             toValue = from
         }
-        op?.invoke(this)
+        op(this)
         if (play) play()
     }
 }
 
 fun Node.follow(time: Duration, path: Shape,
                 easing: Interpolator = Interpolator.EASE_BOTH, reversed: Boolean = false, play: Boolean = true,
-                op: (PathTransition.() -> Unit)? = null): PathTransition {
+                op: PathTransition.() -> Unit = {}): PathTransition {
     return PathTransition(time, path, this).apply {
         interpolator = easing
-        op?.invoke(this)
+        op(this)
         if (reversed && rate > 0.0) rate = -rate
         if (play) play()
     }
 }
 
-fun pause(time: Duration, play: Boolean = true, op: (PauseTransition.() -> Unit)? = null) = PauseTransition(time).apply {
-    op?.invoke(this)
+fun pause(time: Duration, play: Boolean = true, op: PauseTransition.() -> Unit = {}) = PauseTransition(time).apply {
+    op(this)
     if (play) play()
 }
 
@@ -449,7 +444,7 @@ class KeyFrameBuilder(val duration: Duration) {
 
 }
 
-fun <T> WritableValue<T>.animate(endValue: T, duration: Duration, interpolator: Interpolator? = null, op: (Timeline.() -> Unit)? = null) {
+fun <T> WritableValue<T>.animate(endValue: T, duration: Duration, interpolator: Interpolator? = null, op: Timeline.() -> Unit = {}) {
     val writableValue = this
     val timeline = Timeline()
 
@@ -457,12 +452,9 @@ fun <T> WritableValue<T>.animate(endValue: T, duration: Duration, interpolator: 
         keyframe(duration) {
             keyvalue(writableValue, endValue, interpolator)
         }
+        op()
+        play()
     }
-
-    op?.apply { this.invoke(timeline) }
-
-    timeline.play()
-
 }
 
 val Number.millis: Duration get() = Duration.millis(this.toDouble())
@@ -677,11 +669,7 @@ abstract class ViewTransition {
          */
         protected abstract fun reversed(): T
 
-        fun reversed(op: (T.() -> Unit)? = null): T {
-            val reversed = reversed()
-            op?.invoke(reversed)
-            return reversed
-        }
+        fun reversed(op: T.() -> Unit = {}): T = reversed().also(op)
     }
 
     /**

--- a/src/main/java/tornadofx/Async.kt
+++ b/src/main/java/tornadofx/Async.kt
@@ -1,7 +1,5 @@
 package tornadofx
 
-import com.sun.glass.ui.Application
-import com.sun.javafx.tk.Toolkit
 import javafx.application.Platform
 import javafx.beans.property.*
 import javafx.beans.value.ChangeListener
@@ -111,7 +109,7 @@ infix fun <T> Task<T>.success(func: (T) -> Unit) = apply {
         }
     }
 
-    if (Application.isEventThread())
+    if (Platform.isFxApplicationThread())
         attachSuccessHandler()
     else
         runLater { attachSuccessHandler() }
@@ -128,7 +126,7 @@ infix fun <T> Task<T>.fail(func: (Throwable) -> Unit) = apply {
         }
     }
 
-    if (Application.isEventThread())
+    if (Platform.isFxApplicationThread())
         attachFailHandler()
     else
         runLater { attachFailHandler() }
@@ -164,15 +162,11 @@ fun runLater(delay: Duration, op: () -> Unit): FXTimerTask {
  * This method does not block the UI thread even though it halts further execution until the condition is met.
  */
 fun <T> ObservableValue<T>.awaitUntil(condition: (T) -> Boolean) {
-    if (!Toolkit.getToolkit().canStartNestedEventLoop()) {
-        throw IllegalStateException("awaitUntil is not allowed during animation or layout processing")
-    }
-
     val changeListener = object : ChangeListener<T> {
         override fun changed(observable: ObservableValue<out T>?, oldValue: T, newValue: T) {
             if (condition(value)) {
                 runLater {
-                    Toolkit.getToolkit().exitNestedEventLoop(this@awaitUntil, null)
+                    Platform.exitNestedEventLoop(this@awaitUntil, null)
                     removeListener(this)
                 }
             }
@@ -181,7 +175,7 @@ fun <T> ObservableValue<T>.awaitUntil(condition: (T) -> Boolean) {
 
     changeListener.changed(this, value, value)
     addListener(changeListener)
-    Toolkit.getToolkit().enterNestedEventLoop(this)
+    Platform.enterNestedEventLoop(this)
 }
 
 /**

--- a/src/main/java/tornadofx/Async.kt
+++ b/src/main/java/tornadofx/Async.kt
@@ -1,0 +1,480 @@
+package tornadofx
+
+import com.sun.glass.ui.Application
+import com.sun.javafx.tk.Toolkit
+import javafx.application.Platform
+import javafx.beans.property.*
+import javafx.beans.value.ChangeListener
+import javafx.beans.value.ObservableValue
+import javafx.concurrent.Task
+import javafx.concurrent.Worker
+import javafx.scene.Node
+import javafx.scene.control.Labeled
+import javafx.scene.control.ProgressIndicator
+import javafx.scene.layout.BorderPane
+import javafx.scene.layout.Region
+import javafx.util.Duration
+import java.util.*
+import java.util.concurrent.*
+import java.util.concurrent.atomic.AtomicLong
+import java.util.logging.Level
+import java.util.logging.Logger
+
+internal val log = Logger.getLogger("tornadofx.async")
+internal val dummyUncaughtExceptionHandler = Thread.UncaughtExceptionHandler { t, e -> log.log(Level.WARNING, e) { "Exception in ${t?.name ?: "?"}: ${e?.message ?: "?"}" } }
+
+private enum class ThreadPoolType { NoDaemon, Daemon }
+private val threadPools = mutableMapOf<ThreadPoolType, ExecutorService>()
+
+internal val tfxThreadPool: ExecutorService
+    get() = threadPools.getOrPut(ThreadPoolType.NoDaemon) {
+        Executors.newCachedThreadPool(TFXThreadFactory(daemon = false))
+    }
+
+internal val tfxDaemonThreadPool: ExecutorService
+    get() = threadPools.getOrPut(ThreadPoolType.Daemon) {
+        Executors.newCachedThreadPool(TFXThreadFactory(daemon = true))
+    }
+
+
+internal fun shutdownThreadPools() {
+    threadPools.values.forEach { it.shutdown() }
+    threadPools.clear()
+}
+
+private class TFXThreadFactory(val daemon: Boolean) : ThreadFactory {
+    private val threadCounter = AtomicLong(0L)
+    override fun newThread(runnable: Runnable?) = Thread(runnable, threadName()).apply {
+        isDaemon = daemon
+    }
+
+    private fun threadName() = "tornadofx-thread-${threadCounter.incrementAndGet()}" + if (daemon) "-daemon" else ""
+}
+
+private fun awaitTermination(pool: ExecutorService, timeout: Long) {
+    synchronized(pool) {
+        // Disable new tasks from being submitted
+        pool.shutdown()
+    }
+    try {
+        // Wait a while for existing tasks to terminate
+        if (!pool.awaitTermination(timeout, TimeUnit.MILLISECONDS)) {
+            synchronized(pool) {
+                pool.shutdownNow() // Cancel currently executing tasks
+            }
+            // Wait a while for tasks to respond to being cancelled
+            if (!pool.awaitTermination(timeout, TimeUnit.MILLISECONDS)) {
+                log.log(Level.SEVERE, "Executor did not terminate")
+            }
+        }
+    } catch (ie: InterruptedException) {
+        // (Re-)Cancel if current thread also interrupted
+        synchronized(pool) {
+            pool.shutdownNow()
+        }
+        // Preserve interrupt status
+        Thread.currentThread().interrupt()
+    }
+}
+
+fun terminateAsyncExecutors(timeoutMillis: Long) {
+    awaitTermination(tfxThreadPool, timeoutMillis)
+    awaitTermination(tfxDaemonThreadPool, timeoutMillis)
+    threadPools.clear()
+}
+
+fun <T> task(taskStatus: TaskStatus? = null, func: FXTask<*>.() -> T): Task<T> = task(daemon = false, taskStatus = taskStatus, func = func)
+
+fun <T> task(daemon: Boolean = false, taskStatus: TaskStatus? = null, func: FXTask<*>.() -> T): Task<T> = FXTask(taskStatus, func = func).apply {
+    setOnFailed({ (Thread.getDefaultUncaughtExceptionHandler() ?: dummyUncaughtExceptionHandler).uncaughtException(Thread.currentThread(), exception) })
+    if (daemon) {
+        tfxDaemonThreadPool.execute(this)
+    } else {
+        tfxThreadPool.execute(this)
+    }
+}
+
+fun <T> runAsync(status: TaskStatus? = null, func: FXTask<*>.() -> T) = task(status, func)
+
+fun <T> runAsync(daemon: Boolean = false, status: TaskStatus? = null, func: FXTask<*>.() -> T) = task(daemon, status, func)
+
+infix fun <T> Task<T>.ui(func: (T) -> Unit) = success(func)
+
+infix fun <T> Task<T>.success(func: (T) -> Unit) = apply {
+    fun attachSuccessHandler() {
+        if (state == Worker.State.SUCCEEDED) {
+            func(value)
+        } else {
+            setOnSucceeded {
+                func(value)
+            }
+        }
+    }
+
+    if (Application.isEventThread())
+        attachSuccessHandler()
+    else
+        runLater { attachSuccessHandler() }
+}
+
+infix fun <T> Task<T>.fail(func: (Throwable) -> Unit) = apply {
+    fun attachFailHandler() {
+        if (state == Worker.State.FAILED) {
+            func(exception)
+        } else {
+            setOnFailed {
+                func(exception)
+            }
+        }
+    }
+
+    if (Application.isEventThread())
+        attachFailHandler()
+    else
+        runLater { attachFailHandler() }
+}
+
+/**
+ * Run the specified Runnable on the JavaFX Application Thread at some
+ * unspecified time in the future.
+ */
+fun runLater(op: () -> Unit) = Platform.runLater(op)
+
+/**
+ * Run the specified Runnable on the JavaFX Application Thread after a
+ * specified delay.
+ *
+ * runLater(10.seconds) {
+ *     // Do something on the application thread
+ * }
+ *
+ * This function returns a TimerTask which includes a runningProperty as well as the owning timer.
+ * You can cancel the task before the time is up to abort the execution.
+ */
+fun runLater(delay: Duration, op: () -> Unit): FXTimerTask {
+    val timer = Timer(true)
+    val task = FXTimerTask(op, timer)
+    timer.schedule(task, delay.toMillis().toLong())
+    return task
+}
+
+/**
+ * Wait on the UI thread until a certain value is available on this observable.
+ *
+ * This method does not block the UI thread even though it halts further execution until the condition is met.
+ */
+fun <T> ObservableValue<T>.awaitUntil(condition: (T) -> Boolean) {
+    if (!Toolkit.getToolkit().canStartNestedEventLoop()) {
+        throw IllegalStateException("awaitUntil is not allowed during animation or layout processing")
+    }
+
+    val changeListener = object : ChangeListener<T> {
+        override fun changed(observable: ObservableValue<out T>?, oldValue: T, newValue: T) {
+            if (condition(value)) {
+                runLater {
+                    Toolkit.getToolkit().exitNestedEventLoop(this@awaitUntil, null)
+                    removeListener(this)
+                }
+            }
+        }
+    }
+
+    changeListener.changed(this, value, value)
+    addListener(changeListener)
+    Toolkit.getToolkit().enterNestedEventLoop(this)
+}
+
+/**
+ * Wait on the UI thread until this observable value is true.
+ *
+ * This method does not block the UI thread even though it halts further execution until the condition is met.
+ */
+fun ObservableValue<Boolean>.awaitUntil() {
+    this.awaitUntil { it }
+}
+
+/**
+ * Replace this node with a progress node while a long running task
+ * is running and swap it back when complete.
+ *
+ * If this node is Labeled, the graphic property will contain the progress bar instead while the task is running.
+ *
+ * The default progress node is a ProgressIndicator that fills the same
+ * client area as the parent. You can swap the progress node for any Node you like.
+ *
+ * For latch usage see [runAsyncWithOverlay]
+ */
+fun Node.runAsyncWithProgress(latch: CountDownLatch, timeout: Duration? = null, progress: Node = ProgressIndicator()): Task<Boolean> {
+    return if (timeout == null) {
+        runAsyncWithProgress(progress) { latch.await(); true }
+    } else {
+        runAsyncWithOverlay(progress) { latch.await(timeout.toMillis().toLong(), TimeUnit.MILLISECONDS) }
+    }
+}
+
+/**
+ * Replace this node with a progress node while a long running task
+ * is running and swap it back when complete.
+ *
+ * If this node is Labeled, the graphic property will contain the progress bar instead while the task is running.
+ *
+ * The default progress node is a ProgressIndicator that fills the same
+ * client area as the parent. You can swap the progress node for any Node you like.
+ */
+fun <T : Any> Node.runAsyncWithProgress(progress: Node = ProgressIndicator(), op: () -> T): Task<T> {
+    if (this is Labeled) {
+        val oldGraphic = graphic
+        (progress as? Region)?.setPrefSize(16.0, 16.0)
+        graphic = progress
+        return task {
+            try {
+                op()
+            } finally {
+                runLater {
+                    this@runAsyncWithProgress.graphic = oldGraphic
+                }
+            }
+        }
+    } else {
+        val paddingHorizontal = (this as? Region)?.paddingHorizontal?.toDouble() ?: 0.0
+        val paddingVertical = (this as? Region)?.paddingVertical?.toDouble() ?: 0.0
+        (progress as? Region)?.setPrefSize(boundsInParent.width - paddingHorizontal, boundsInParent.height - paddingVertical)
+        val children = requireNotNull(parent.getChildList()) { "This node has no child list, and cannot contain the progress node" }
+        val index = children.indexOf(this)
+        children.add(index, progress)
+        removeFromParent()
+        return task {
+            val result = op()
+            runLater {
+                children.add(index, this@runAsyncWithProgress)
+                progress.removeFromParent()
+            }
+            result
+        }
+    }
+}
+
+/**
+ * Covers node with overlay (by default - an instance of [MaskPane]) until [latch] is released by another thread.
+ * It's useful when more control over async execution is needed, like:
+ * * A task already have its thread and overlay should be visible until some callback is invoked (it should invoke
+ * [CountDownLatch.countDown] or [Latch.release]) in order to unlock UI. Keep in mind that if [latch] is not released
+ * and [timeout] is not set, overlay may never get removed.
+ * * An overlay should be removed after some time, even if task is getting unresponsive (use [timeout] for this).
+ * Keep in mind that this timeout applies to overlay only, not the latch itself.
+ * * In addition to masking UI, you need an access to property indicating if background process is running;
+ * [Latch.lockedProperty] serves exactly that purpose.
+ * * More threads are involved in task execution. You can create a [CountDownLatch] for number of workers, call
+ * [CountDownLatch.countDown] from each of them when it's done and overlay will stay visible until all workers finish
+ * their jobs.
+ *
+ * @param latch an instance of [CountDownLatch], usage of [Latch] is recommended.
+ * @param timeout timeout after which overlay will be removed anyway. Can be `null` (which means no timeout).
+ * @param overlayNode optional custom overlay node. For best effect set transparency.
+ *
+ * # Example 1
+ * The simplest case: overlay is visible for two seconds - until latch release. Replace [Thread.sleep] with any
+ * blocking action. Manual thread creation is for the sake of the example only.
+ *
+ * ```kotlin
+ * val latch = Latch()
+ * root.runAsyncWithOverlay(latch) ui {
+ *   //UI action
+ * }
+ *
+ * Thread({
+ *   Thread.sleep(2000)
+ *   latch.release()
+ * }).start()
+ * ```
+ *
+ * # Example 2
+ * The latch won't be released until both workers are done. In addition, until workers are done, button will stay
+ * disabled. New latch has to be created and rebound every time.
+ *
+ * ```kotlin
+ * val latch = Latch(2)
+ * root.runAsyncWithOverlay(latch)
+ * button.disableWhen(latch.lockedProperty())
+ * runAsync(worker1.work(); latch.countDown())
+ * runAsync(worker2.work(); latch.countDown())
+ */
+@JvmOverloads
+fun Node.runAsyncWithOverlay(latch: CountDownLatch, timeout: Duration? = null, overlayNode: Node = MaskPane()): Task<Boolean> {
+    return if (timeout == null) {
+        runAsyncWithOverlay(overlayNode) { latch.await(); true }
+    } else {
+        runAsyncWithOverlay(overlayNode) { latch.await(timeout.toMillis().toLong(), TimeUnit.MILLISECONDS) }
+    }
+}
+
+/**
+ * Runs given task in background thread, covering node with overlay (default one is [MaskPane]) until task is done.
+ *
+ * # Example
+ *
+ * ```kotlin
+ * root.runAsyncWithOverlay {
+ *   Thread.sleep(2000)
+ * } ui {
+ *   //UI action
+ * }
+ * ```
+ *
+ * @param overlayNode optional custom overlay node. For best effect set transparency.
+ */
+@JvmOverloads
+fun <T : Any> Node.runAsyncWithOverlay(overlayNode: Node = MaskPane(), op: () -> T): Task<T> {
+    val overlayContainer = stackpane { add(overlayNode) }
+
+    replaceWith(overlayContainer)
+    overlayContainer.children.add(0, this)
+
+    return task {
+        try {
+            op()
+        } finally {
+            runLater { overlayContainer.replaceWith(this@runAsyncWithOverlay) }
+        }
+    }
+}
+
+/**
+ * A basic mask pane, intended for blocking gui underneath. Styling example:
+ *
+ * ```css
+ * .mask-pane {
+ *     -fx-background-color: rgba(0,0,0,0.5);
+ *     -fx-accent: aliceblue;
+ * }
+ *
+ * .mask-pane > .progress-indicator {
+ *     -fx-max-width: 300;
+ *     -fx-max-height: 300;
+ * }
+ * ```
+ */
+class MaskPane : BorderPane() {
+    init {
+        addClass("mask-pane")
+        center = progressindicator()
+    }
+
+    override fun getUserAgentStylesheet() = MaskPane::class.java.getResource("maskpane.css").toExternalForm()!!
+}
+
+/**
+ * Adds some superpowers to good old [CountDownLatch], like exposed [lockedProperty] or ability to release latch
+ * immediately.
+ *
+ * All documentation of superclass applies here. Default behavior has not been altered.
+ */
+class Latch(count: Int) : CountDownLatch(count) {
+    /**
+     * Initializes latch with count of `1`, which means that the first invocation of [countDown] will allow all
+     * waiting threads to proceed.
+     */
+    constructor() : this(1)
+
+    private val lockedProperty by lazy { ReadOnlyBooleanWrapper(locked) }
+
+    /**
+     * Locked state of this latch exposed as a property. Keep in mind that latch instance can be used only once, so
+     * this property has to rebound every time.
+     */
+    fun lockedProperty(): ReadOnlyBooleanProperty = lockedProperty.readOnlyProperty
+
+    /**
+     * Locked state of this latch. `true` if and only if [CountDownLatch.getCount] is greater than `0`.
+     * Once latch is released it changes to `false` permanently.
+     */
+    val locked get() = count > 0L
+
+    /**
+     * Releases latch immediately and allows waiting thread(s) to proceed. Can be safely used if this latch has been
+     * initialized with `count` of `1`, should be used with care otherwise - [countDown] invocations ar preferred in
+     * such cases.
+     */
+    fun release() = (1..count).forEach { countDown() } //maybe not the prettiest way, but works fine
+
+    override fun countDown() {
+        super.countDown()
+        lockedProperty.set(locked)
+    }
+}
+
+class FXTimerTask(val op: () -> Unit, val timer: Timer) : TimerTask() {
+    private val internalRunning = ReadOnlyBooleanWrapper(false)
+    val runningProperty: ReadOnlyBooleanProperty get() = internalRunning.readOnlyProperty
+    val running: Boolean get() = runningProperty.value
+
+    private val internalCompleted = ReadOnlyBooleanWrapper(false)
+    val completedProperty: ReadOnlyBooleanProperty get() = internalCompleted.readOnlyProperty
+    val completed: Boolean get() = completedProperty.value
+
+    override fun run() {
+        internalRunning.value = true
+        Platform.runLater {
+            try {
+                op()
+            } finally {
+                internalRunning.value = false
+                internalCompleted.value = true
+            }
+        }
+    }
+}
+
+class FXTask<T>(val status: TaskStatus? = null, val func: FXTask<*>.() -> T) : Task<T>() {
+    private var internalCompleted = ReadOnlyBooleanWrapper(false)
+    val completedProperty: ReadOnlyBooleanProperty get() = internalCompleted.readOnlyProperty
+    val completed: Boolean get() = completedProperty.value
+
+    override fun call() = func(this)
+
+    init {
+        status?.item = this
+    }
+
+    override fun succeeded() {
+        internalCompleted.value = true
+    }
+
+    override fun failed() {
+        internalCompleted.value = true
+    }
+
+    override fun cancelled() {
+        internalCompleted.value = true
+    }
+
+    override public fun updateProgress(workDone: Long, max: Long) {
+        super.updateProgress(workDone, max)
+    }
+
+    override public fun updateProgress(workDone: Double, max: Double) {
+        super.updateProgress(workDone, max)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun value(v: Any) {
+        super.updateValue(v as T)
+    }
+
+    override public fun updateTitle(t: String?) {
+        super.updateTitle(t)
+    }
+
+    override public fun updateMessage(m: String?) {
+        super.updateMessage(m)
+    }
+
+}
+
+open class TaskStatus : ItemViewModel<FXTask<*>>() {
+    val running: ReadOnlyBooleanProperty = bind { SimpleBooleanProperty().apply { if (item != null) bind(item.runningProperty()) } }
+    val completed: ReadOnlyBooleanProperty = bind { SimpleBooleanProperty().apply { if (item != null) bind(item.completedProperty) } }
+    val message: ReadOnlyStringProperty = bind { SimpleStringProperty().apply { if (item != null) bind(item.messageProperty()) } }
+    val title: ReadOnlyStringProperty = bind { SimpleStringProperty().apply { if (item != null) bind(item.titleProperty()) } }
+    val progress: ReadOnlyDoubleProperty = bind { SimpleDoubleProperty().apply { if (item != null) bind(item.progressProperty()) } }
+}

--- a/src/main/java/tornadofx/AutoCompleteComboBoxSkin.ktx
+++ b/src/main/java/tornadofx/AutoCompleteComboBoxSkin.ktx
@@ -19,9 +19,9 @@ import javafx.util.Callback
  * Extension function to combobox to add autocomplete capabilities
  * Accept in parameter a callback to create the autocomplete list based on input text
  * Default filter use the string produced by the converter of combobox and search with contains ignore case the occurrence of typed text
- * @param automaticPopupWidth Use the width required to display all content. Default: false
+ * @param automaticPopupWidth Use the width required to display all content. Default: true
  */
-fun <T> ComboBox<T>.makeAutocompletable(automaticPopupWidth: Boolean = false, autoCompleteFilter: ((String) -> List<T>)? = null) {
+fun <T> ComboBox<T>.makeAutocompletable(automaticPopupWidth: Boolean = true, autoCompleteFilter: ((String) -> List<T>)? = null) {
     skin = AutoCompleteComboBoxSkin(this, autoCompleteFilter, automaticPopupWidth)
 }
 
@@ -225,7 +225,9 @@ open class AutoCompleteComboBoxSkin<T>(val comboBox: ComboBox<T>, autoCompleteFi
         if (!automaticPopupWidth) {
             // Note that we cannot bind prefWidthProperty because JavaFX sets
             // the preferred width upon reconfiguration. (ComboBoxPopupControl.java:322)
-            comboBox.widthProperty().onChange { listView.prefWidth = it }
+            comboBox.widthProperty().onChange {
+                if (!listView.prefWidthProperty().isBound) listView.prefWidth = it
+            }
         }
         updateCellFactory()
         updateButtonCell()

--- a/src/main/java/tornadofx/Charts.kt
+++ b/src/main/java/tornadofx/Charts.kt
@@ -7,7 +7,7 @@ import javafx.scene.chart.*
 /**
  * Create a PieChart with optional title data and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun EventTarget.piechart(title: String? = null, data: ObservableList<PieChart.Data>? = null, op: (PieChart.() -> Unit)? = null): PieChart {
+fun EventTarget.piechart(title: String? = null, data: ObservableList<PieChart.Data>? = null, op: PieChart.() -> Unit = {}): PieChart {
     val chart = if (data != null) PieChart(data) else PieChart()
     chart.title = title
     return opcr(this, chart, op)
@@ -19,9 +19,9 @@ fun EventTarget.piechart(title: String? = null, data: ObservableList<PieChart.Da
  *
  * @return The new Data entry
  */
-fun PieChart.data(name: String, value: Double, op: (PieChart.Data.() -> Unit)? = null) = PieChart.Data(name, value).apply {
+fun PieChart.data(name: String, value: Double, op: PieChart.Data.() -> Unit = {}) = PieChart.Data(name, value).apply {
     data.add(this)
-    if (op != null) op(this)
+    op(this)
 }
 
 /**
@@ -33,7 +33,7 @@ fun PieChart.data(value: Map<String, Double>) = value.forEach { data(it.key, it.
 /**
  * Create a LineChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.linechart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: (LineChart<X, Y>.() -> Unit)? = null): LineChart<X, Y> {
+fun <X, Y> EventTarget.linechart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: LineChart<X, Y>.() -> Unit = {}): LineChart<X, Y> {
     val chart = LineChart(x, y)
     chart.title = title
     return opcr(this, chart, op)
@@ -42,7 +42,7 @@ fun <X, Y> EventTarget.linechart(title: String? = null, x: Axis<X>, y: Axis<Y>, 
 /**
  * Create an AreaChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.areachart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: (AreaChart<X, Y>.() -> Unit)? = null): AreaChart<X, Y> {
+fun <X, Y> EventTarget.areachart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: AreaChart<X, Y>.() -> Unit = {}): AreaChart<X, Y> {
     val chart = AreaChart(x, y)
     chart.title = title
     return opcr(this, chart, op)
@@ -51,7 +51,7 @@ fun <X, Y> EventTarget.areachart(title: String? = null, x: Axis<X>, y: Axis<Y>, 
 /**
  * Create a BubbleChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.bubblechart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: (BubbleChart<X, Y>.() -> Unit)? = null): BubbleChart<X, Y> {
+fun <X, Y> EventTarget.bubblechart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: BubbleChart<X, Y>.() -> Unit = {}): BubbleChart<X, Y> {
     val chart = BubbleChart(x, y)
     chart.title = title
     return opcr(this, chart, op)
@@ -60,7 +60,7 @@ fun <X, Y> EventTarget.bubblechart(title: String? = null, x: Axis<X>, y: Axis<Y>
 /**
  * Create a ScatterChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.scatterchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: (ScatterChart<X, Y>.() -> Unit)? = null): ScatterChart<X, Y> {
+fun <X, Y> EventTarget.scatterchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: ScatterChart<X, Y>.() -> Unit = {}): ScatterChart<X, Y> {
     val chart = ScatterChart(x, y)
     chart.title = title
     return opcr(this, chart, op)
@@ -69,7 +69,7 @@ fun <X, Y> EventTarget.scatterchart(title: String? = null, x: Axis<X>, y: Axis<Y
 /**
  * Create a BarChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.barchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: (BarChart<X, Y>.() -> Unit)? = null): BarChart<X, Y> {
+fun <X, Y> EventTarget.barchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: BarChart<X, Y>.() -> Unit = {}): BarChart<X, Y> {
     val chart = BarChart(x, y)
     chart.title = title
     return opcr(this, chart, op)
@@ -78,7 +78,7 @@ fun <X, Y> EventTarget.barchart(title: String? = null, x: Axis<X>, y: Axis<Y>, o
 /**
  * Create a BarChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.stackedbarchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: (StackedBarChart<X, Y>.() -> Unit)? = null): StackedBarChart<X, Y> {
+fun <X, Y> EventTarget.stackedbarchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: StackedBarChart<X, Y>.() -> Unit = {}): StackedBarChart<X, Y> {
     val chart = StackedBarChart(x, y)
     chart.title = title
     return opcr(this, chart, op)
@@ -88,11 +88,11 @@ fun <X, Y> EventTarget.stackedbarchart(title: String? = null, x: Axis<X>, y: Axi
  * Add a new XYChart.Series with the given name to the given Chart. Optionally specify a list data for the new series or
  * add data with the optional op that will be performed on the created series object.
  */
-fun <X, Y, ChartType : XYChart<X, Y>> ChartType.series(name: String, elements: ObservableList<XYChart.Data<X, Y>>? = null, op: ((XYChart.Series<X, Y>).() -> Unit)? = null): XYChart.Series<X, Y> {
+fun <X, Y, ChartType : XYChart<X, Y>> ChartType.series(name: String, elements: ObservableList<XYChart.Data<X, Y>>? = null, op: (XYChart.Series<X, Y>).() -> Unit = {}): XYChart.Series<X, Y> {
     val series = XYChart.Series<X, Y>()
     series.name = name
     if (elements != null) series.data = elements
-    if (op != null) op(series)
+    op(series)
     data.add(series)
     return series
 }
@@ -103,10 +103,10 @@ fun <X, Y, ChartType : XYChart<X, Y>> ChartType.series(name: String, elements: O
  *
  * @return The new Data entry
  */
-fun <X, Y> XYChart.Series<X, Y>.data(x: X, y: Y, extra: Any? = null, op: ((XYChart.Data<X, Y>).() -> Unit)? = null) = XYChart.Data<X, Y>(x, y).apply {
+fun <X, Y> XYChart.Series<X, Y>.data(x: X, y: Y, extra: Any? = null, op: (XYChart.Data<X, Y>).() -> Unit = {}) = XYChart.Data<X, Y>(x, y).apply {
     if (extra != null) extraValue = extra
     data.add(this)
-    if (op != null) op(this)
+    op(this)
 }
 
 /**
@@ -131,10 +131,10 @@ class MultiSeries<X, Y>(val series: List<XYChart.Series<X, Y>>, val chart: XYCha
  * }
  * </pre>
  */
-fun <X, Y, ChartType : XYChart<X, Y>> ChartType.multiseries(vararg names: String, op: ((MultiSeries<X, Y>).() -> Unit)? = null): MultiSeries<X, Y> {
+fun <X, Y, ChartType : XYChart<X, Y>> ChartType.multiseries(vararg names: String, op: (MultiSeries<X, Y>).() -> Unit = {}): MultiSeries<X, Y> {
     val series = names.map { XYChart.Series<X, Y>().apply { name = it } }
     val multiseries = MultiSeries(series, this)
-    op?.invoke(multiseries)
+    op(multiseries)
     data.addAll(series)
     return multiseries
 }

--- a/src/main/java/tornadofx/ChildInterceptor.kt
+++ b/src/main/java/tornadofx/ChildInterceptor.kt
@@ -1,0 +1,32 @@
+package tornadofx
+
+import javafx.event.EventTarget
+import javafx.scene.Node
+/**
+ * An interceptor that can veto or provide another mechanism for adding children to their parent.
+ *
+ * All interceptors called for all builders right before the default mechanism adds the newly created
+ * node to the parent container. Returning false means that the default will be used. Returning true means
+ * that you added the child yourself and that the default mechanism should do nothing.
+ *
+ * This is useful for layout containers that need special handling when adding child nodes.
+ *
+ * Example: MigPane needs to add a default ComponentConstraint object to be able to manipulate the
+ * constraint after the child is added.
+ * ```
+ * class MigPaneChildInterceptor: ChildInterceptor{
+ *      override fun invoke(parent: EventTarget, node: Node, index: Int?): Boolean{
+ *          return when(parent){
+ *              is MigPane ->  {parent.add(node, CC()); true}
+ *              else -> false
+ *          }
+ *      }
+ * }
+ * ```
+ * @sample tornadofx.tests.FirstInterceptor
+ * @sample tornadofx.tests.SecondInterceptor
+ *
+ */
+interface ChildInterceptor {
+    operator fun invoke(parent: EventTarget, node: Node, index: Int?):Boolean
+}

--- a/src/main/java/tornadofx/Collections.kt
+++ b/src/main/java/tornadofx/Collections.kt
@@ -3,10 +3,7 @@
 package tornadofx
 
 import javafx.beans.WeakListener
-import javafx.collections.ListChangeListener
-import javafx.collections.ObservableList
-import javafx.collections.ObservableSet
-import javafx.collections.SetChangeListener
+import javafx.collections.*
 import tornadofx.FX.IgnoreParentBuilder.No
 import tornadofx.FX.IgnoreParentBuilder.Once
 import java.lang.ref.WeakReference
@@ -16,6 +13,7 @@ import java.util.*
  * Moves the given **T** item to the specified index
  */
 fun <T> MutableList<T>.move(item: T, newIndex: Int) {
+    check(newIndex in 0 until size)
     val currentIndex = indexOf(item)
     if (currentIndex < 0) return
     removeAt(currentIndex)
@@ -26,12 +24,11 @@ fun <T> MutableList<T>.move(item: T, newIndex: Int) {
  * Moves the given item at the `oldIndex` to the `newIndex`
  */
 fun <T> MutableList<T>.moveAt(oldIndex: Int, newIndex: Int) {
+    check(oldIndex in 0 until size)
+    check(newIndex in 0 until size)
     val item = this[oldIndex]
     removeAt(oldIndex)
-    if (oldIndex > newIndex)
-        add(newIndex, item)
-    else
-        add(newIndex - 1, item)
+    add(newIndex, item)
 }
 
 /**
@@ -51,8 +48,8 @@ fun <T> MutableList<T>.moveAll(newIndex: Int, predicate: (T) -> Boolean) {
  */
 fun <T> MutableList<T>.moveUpAt(index: Int) {
     if (index == 0) return
-    if (index !in 0 until size) throw Exception("Invalid index $index for MutableList of size $size")
-    val newIndex = index + 1
+    check(index in indices, { "Invalid index $index for MutableList of size $size" })
+    val newIndex = index - 1
     val item = this[index]
     removeAt(index)
     add(newIndex, item)
@@ -64,8 +61,8 @@ fun <T> MutableList<T>.moveUpAt(index: Int) {
  */
 fun <T> MutableList<T>.moveDownAt(index: Int) {
     if (index == size - 1) return
-    if (index !in indices) throw Exception("Invalid index $index for MutableList of size $size")
-    val newIndex = index - 1
+    check(index in indices, { "Invalid index $index for MutableList of size $size" })
+    val newIndex = index + 1
     val item = this[index]
     removeAt(index)
     add(newIndex, item)
@@ -302,3 +299,6 @@ class SetConversionListener<SourceType, TargetType>(targetList: MutableList<Targ
 fun <T> ObservableList<T>.invalidate() {
     if (isNotEmpty()) this[0] = this[0]
 }
+
+
+fun <T> observableList(vararg entries: T) = FXCollections.observableArrayList<T>(entries.toList())

--- a/src/main/java/tornadofx/Controls.kt
+++ b/src/main/java/tornadofx/Controls.kt
@@ -2,13 +2,9 @@
 
 package tornadofx
 
-import javafx.beans.binding.BooleanBinding
-import javafx.beans.binding.BooleanExpression
 import javafx.beans.property.ObjectProperty
 import javafx.beans.property.Property
-import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
-import javafx.beans.value.ChangeListener
 import javafx.beans.value.ObservableValue
 import javafx.collections.ObservableMap
 import javafx.event.EventTarget
@@ -18,7 +14,6 @@ import javafx.scene.control.*
 import javafx.scene.image.Image
 import javafx.scene.image.ImageView
 import javafx.scene.layout.Pane
-import javafx.scene.layout.VBox
 import javafx.scene.paint.Color
 import javafx.scene.text.Text
 import javafx.scene.text.TextFlow
@@ -26,13 +21,12 @@ import javafx.scene.web.HTMLEditor
 import javafx.scene.web.WebView
 import javafx.util.StringConverter
 import java.time.LocalDate
-import kotlin.reflect.KClass
 
-fun EventTarget.webview(op: (WebView.() -> Unit)? = null) = opcr(this, WebView(), op)
+fun EventTarget.webview(op: WebView.() -> Unit = {}) = opcr(this, WebView(), op)
 
 enum class ColorPickerMode { Button, MenuButton, SplitMenuButton }
 
-fun EventTarget.colorpicker(color: Color? = null, mode: ColorPickerMode = ColorPickerMode.Button, op: (ColorPicker.() -> Unit)? = null): ColorPicker {
+fun EventTarget.colorpicker(color: Color? = null, mode: ColorPickerMode = ColorPickerMode.Button, op: ColorPicker.() -> Unit = {}): ColorPicker {
     val picker = ColorPicker()
     if (mode == ColorPickerMode.MenuButton) picker.addClass(ColorPicker.STYLE_CLASS_BUTTON)
     else if (mode == ColorPickerMode.SplitMenuButton) picker.addClass(ColorPicker.STYLE_CLASS_SPLIT_BUTTON)
@@ -40,18 +34,9 @@ fun EventTarget.colorpicker(color: Color? = null, mode: ColorPickerMode = ColorP
     return opcr(this, picker, op)
 }
 
-fun EventTarget.tabpane(op: (TabPane.() -> Unit)? = null) = opcr(this, TabPane(), op)
+fun EventTarget.textflow(op: TextFlow.() -> Unit = {}) = opcr(this, TextFlow(), op)
 
-fun EventTarget.textflow(op: (TextFlow.() -> Unit)? = null) = opcr(this, TextFlow(), op)
-
-fun EventTarget.text(op: (Text.() -> Unit)? = null) = opcr(this, Text(), op)
-
-fun <T : Node> TabPane.tab(text: String, content: T, op: (T.() -> Unit)? = null): Tab {
-    val tab = Tab(text, content)
-    tabs.add(tab)
-    if (op != null) op(content)
-    return tab
-}
+fun EventTarget.text(op: Text.() -> Unit = {}) = opcr(this, Text(), op)
 
 internal val EventTarget.properties: ObservableMap<Any, Any>
     get() = when (this) {
@@ -75,145 +60,6 @@ var EventTarget.tag: Any?
         tagProperty.value = value
     }
 
-@Deprecated("Use the tab builder that extracts the closeable state from UIComponent.closeable instead", ReplaceWith("add(uiComponent)"))
-fun TabPane.tab(uiComponent: UIComponent, closable: Boolean = true, op: (Tab.() -> Unit)? = null): Tab {
-    val tab = Tab()
-    tab.isClosable = closable
-    tab.textProperty().bind(uiComponent.titleProperty)
-    tab.content = uiComponent.root
-    tabs.add(tab)
-    op?.invoke(tab)
-    return tab
-}
-
-inline fun <reified  T: UIComponent> TabPane.tab(noinline op: (Tab.() -> Unit)? = null) = tab(T::class, op)
-fun TabPane.tab(uiComponent: KClass<out UIComponent>, op: (Tab.() -> Unit)? = null) = tab(find(uiComponent), op)
-
-fun TabPane.tab(uiComponent: UIComponent, op: (Tab.() -> Unit)? = null): Tab {
-    add(uiComponent.root)
-    val tab = tabs.last()
-    op?.invoke(tab)
-    return tab
-}
-
-fun <T : Node> Iterable<T>.contains(cmp: UIComponent) = any { it == cmp.root }
-
-fun TabPane.contains(cmp: UIComponent) = tabs.map { it.content }.contains(cmp)
-
-fun Tab.disableWhen(predicate: ObservableValue<Boolean>) = disableProperty().cleanBind(predicate)
-fun Tab.enableWhen(predicate: ObservableValue<Boolean>) {
-    val binding = if (predicate is BooleanBinding) predicate.not() else predicate.toBinding().not()
-    disableProperty().cleanBind(binding)
-}
-fun Tab.closeableWhen(predicate: ObservableValue<Boolean>) {
-    closableProperty().bind(predicate)
-}
-
-fun Tab.visibleWhen(predicate: ObservableValue<Boolean>) {
-    fun updateState() {
-        if (predicate.value.not()) tabPane.tabs.remove(this)
-        else if (this !in tabPane.tabs) tabPane.tabs.add(this)
-    }
-    updateState()
-    predicate.onChange { updateState() }
-}
-
-val TabPane.savable: BooleanExpression
-    get() {
-        val savable = SimpleBooleanProperty(true)
-
-        fun updateState() {
-            savable.cleanBind(contentUiComponent<UIComponent>()?.savable ?: SimpleBooleanProperty(Workspace.defaultSavable))
-        }
-
-        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
-
-        updateState()
-
-        selectionModel.selectedItem?.contentProperty()?.addListener(contentChangeListener)
-        selectionModel.selectedItemProperty().addListener { _, oldTab, newTab ->
-            updateState()
-            oldTab?.contentProperty()?.removeListener(contentChangeListener)
-            newTab?.contentProperty()?.addListener(contentChangeListener)
-        }
-
-        return savable
-    }
-
-val TabPane.deletable: BooleanExpression
-    get() {
-        val deletable = SimpleBooleanProperty(true)
-
-        fun updateState() {
-            deletable.cleanBind(contentUiComponent<UIComponent>()?.deletable ?: SimpleBooleanProperty(Workspace.defaultDeletable))
-        }
-
-        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
-
-        updateState()
-
-        selectionModel.selectedItem?.contentProperty()?.addListener(contentChangeListener)
-        selectionModel.selectedItemProperty().addListener { _, oldTab, newTab ->
-            updateState()
-            oldTab?.contentProperty()?.removeListener(contentChangeListener)
-            newTab?.contentProperty()?.addListener(contentChangeListener)
-        }
-
-        return deletable
-    }
-
-val TabPane.refreshable: BooleanExpression
-    get() {
-        val refreshable = SimpleBooleanProperty(true)
-
-        fun updateState() {
-            refreshable.cleanBind(contentUiComponent<UIComponent>()?.refreshable ?: SimpleBooleanProperty(Workspace.defaultRefreshable))
-        }
-
-        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
-
-        updateState()
-
-        selectionModel.selectedItem?.contentProperty()?.addListener(contentChangeListener)
-        selectionModel.selectedItemProperty().addListener { _, oldTab, newTab ->
-            updateState()
-            oldTab?.contentProperty()?.removeListener(contentChangeListener)
-            newTab?.contentProperty()?.addListener(contentChangeListener)
-        }
-
-        return refreshable
-    }
-
-inline fun <reified T : UIComponent> TabPane.contentUiComponent(): T? = selectionModel.selectedItem?.content?.uiComponent<T>()
-fun TabPane.onDelete() = contentUiComponent<UIComponent>()?.onDelete()
-fun TabPane.onSave() = contentUiComponent<UIComponent>()?.onSave()
-fun TabPane.onCreate() = contentUiComponent<UIComponent>()?.onCreate()
-fun TabPane.onRefresh() = contentUiComponent<UIComponent>()?.onRefresh()
-fun TabPane.onNavigateBack() = contentUiComponent<UIComponent>()?.onNavigateBack() ?: true
-fun TabPane.onNavigateForward() = contentUiComponent<UIComponent>()?.onNavigateForward() ?: true
-
-fun TabPane.tab(text: String? = null, tag: Any? = null, op: (Tab.() -> Unit)? = null): Tab {
-    val tab = Tab(text ?: tag?.toString())
-    tab.tag = tag
-    tabs.add(tab)
-    op?.invoke(tab)
-    return tab
-}
-
-fun Tab.whenSelected(op: () -> Unit) {
-    selectedProperty().onChange { if (it) op() }
-}
-
-fun Tab.select() = apply { tabPane.selectionModel.select(this) }
-
-@Deprecated("No need to use the content{} wrapper anymore, just use a builder directly inside the Tab", ReplaceWith("no content{} wrapper"), DeprecationLevel.WARNING)
-fun Tab.content(op: Pane.() -> Unit): Node {
-    val fake = VBox()
-    op(fake)
-    content = if (fake.children.size == 1) fake.children.first() else fake
-    return content
-}
-
 @Deprecated("Properties set on the fake node would be lost. Do not use this function.", ReplaceWith("Manually adding children"), DeprecationLevel.WARNING)
 fun children(addTo: MutableList<Node>, op: Pane.() -> Unit) {
     val fake = Pane()
@@ -222,58 +68,58 @@ fun children(addTo: MutableList<Node>, op: Pane.() -> Unit) {
 }
 
 
-fun EventTarget.text(initialValue: String? = null, op: (Text.() -> Unit)? = null) = opcr(this, Text().apply { if (initialValue != null) text = initialValue }, op)
-fun EventTarget.text(property: Property<String>, op: (Text.() -> Unit)? = null) = text().apply {
+fun EventTarget.text(initialValue: String? = null, op: Text.() -> Unit = {}) = opcr(this, Text().apply { if (initialValue != null) text = initialValue }, op)
+fun EventTarget.text(property: Property<String>, op: Text.() -> Unit = {}) = text().apply {
     bind(property)
-    op?.invoke(this)
+    op(this)
 }
 
-fun EventTarget.text(observable: ObservableValue<String>, op: (Text.() -> Unit)? = null) = text().apply {
+fun EventTarget.text(observable: ObservableValue<String>, op: Text.() -> Unit = {}) = text().apply {
     bind(observable)
-    op?.invoke(this)
+    op(this)
 }
 
-fun EventTarget.textfield(value: String? = null, op: (TextField.() -> Unit)? = null) = opcr(this, TextField().apply { if (value != null) text = value }, op)
+fun EventTarget.textfield(value: String? = null, op: TextField.() -> Unit = {}) = opcr(this, TextField().apply { if (value != null) text = value }, op)
 
-fun EventTarget.textfield(property: ObservableValue<String>, op: (TextField.() -> Unit)? = null) = textfield().apply {
+fun EventTarget.textfield(property: ObservableValue<String>, op: TextField.() -> Unit = {}) = textfield().apply {
     bind(property)
-    op?.invoke(this)
+    op(this)
 }
 
 @JvmName("textfieldNumber")
-fun EventTarget.textfield(property: ObservableValue<Number>, op: (TextField.() -> Unit)? = null) = textfield().apply {
+fun EventTarget.textfield(property: ObservableValue<Number>, op: TextField.() -> Unit = {}) = textfield().apply {
     bind(property)
-    op?.invoke(this)
+    op(this)
 }
 
-fun EventTarget.passwordfield(value: String? = null, op: (PasswordField.() -> Unit)? = null) = opcr(this, PasswordField().apply { if (value != null) text = value }, op)
-fun EventTarget.passwordfield(property: ObservableValue<String>, op: (PasswordField.() -> Unit)? = null) = passwordfield().apply {
+fun EventTarget.passwordfield(value: String? = null, op: PasswordField.() -> Unit = {}) = opcr(this, PasswordField().apply { if (value != null) text = value }, op)
+fun EventTarget.passwordfield(property: ObservableValue<String>, op: PasswordField.() -> Unit = {}) = passwordfield().apply {
     bind(property)
-    op?.invoke(this)
+    op(this)
 }
 
-fun <T> EventTarget.textfield(property: Property<T>, converter: StringConverter<T>, op: (TextField.() -> Unit)? = null) = textfield().apply {
+fun <T> EventTarget.textfield(property: Property<T>, converter: StringConverter<T>, op: TextField.() -> Unit = {}) = textfield().apply {
     textProperty().bindBidirectional(property, converter)
     ViewModel.register(textProperty(), property)
-    op?.invoke(this)
+    op(this)
 }
 
-fun EventTarget.datepicker(op: (DatePicker.() -> Unit)? = null) = opcr(this, DatePicker(), op)
-fun EventTarget.datepicker(property: Property<LocalDate>, op: (DatePicker.() -> Unit)? = null) = datepicker().apply {
+fun EventTarget.datepicker(op: DatePicker.() -> Unit = {}) = opcr(this, DatePicker(), op)
+fun EventTarget.datepicker(property: Property<LocalDate>, op: DatePicker.() -> Unit = {}) = datepicker().apply {
     bind(property)
-    op?.invoke(this)
+    op(this)
 }
 
-fun EventTarget.textarea(value: String? = null, op: (TextArea.() -> Unit)? = null) = opcr(this, TextArea().apply { if (value != null) text = value }, op)
-fun EventTarget.textarea(property: ObservableValue<String>, op: (TextArea.() -> Unit)? = null) = textarea().apply {
+fun EventTarget.textarea(value: String? = null, op: TextArea.() -> Unit = {}) = opcr(this, TextArea().apply { if (value != null) text = value }, op)
+fun EventTarget.textarea(property: ObservableValue<String>, op: TextArea.() -> Unit = {}) = textarea().apply {
     bind(property)
-    op?.invoke(this)
+    op(this)
 }
 
-fun <T> EventTarget.textarea(property: Property<T>, converter: StringConverter<T>, op: (TextArea.() -> Unit)? = null) = textarea().apply {
+fun <T> EventTarget.textarea(property: Property<T>, converter: StringConverter<T>, op: TextArea.() -> Unit = {}) = textarea().apply {
     textProperty().bindBidirectional(property, converter)
     ViewModel.register(textProperty(), property)
-    op?.invoke(this)
+    op(this)
 }
 
 fun EventTarget.buttonbar(buttonOrder: String? = null, op: (ButtonBar.() -> Unit)): ButtonBar {
@@ -282,25 +128,25 @@ fun EventTarget.buttonbar(buttonOrder: String? = null, op: (ButtonBar.() -> Unit
     return opcr(this, bar, op)
 }
 
-fun EventTarget.htmleditor(html: String? = null, op: (HTMLEditor.() -> Unit)? = null) = opcr(this, HTMLEditor().apply { if (html != null) htmlText = html }, op)
+fun EventTarget.htmleditor(html: String? = null, op: HTMLEditor.() -> Unit = {}) = opcr(this, HTMLEditor().apply { if (html != null) htmlText = html }, op)
 
-fun EventTarget.checkbox(text: String? = null, property: Property<Boolean>? = null, op: (CheckBox.() -> Unit)? = null) = opcr(this, CheckBox(text).apply {
+fun EventTarget.checkbox(text: String? = null, property: Property<Boolean>? = null, op: CheckBox.() -> Unit = {}) = opcr(this, CheckBox(text).apply {
     if (property != null) bind(property)
 }, op)
 
-fun EventTarget.progressindicator(op: (ProgressIndicator.() -> Unit)? = null) = opcr(this, ProgressIndicator(), op)
-fun EventTarget.progressindicator(property: Property<Number>, op: (ProgressIndicator.() -> Unit)? = null) = progressindicator().apply {
+fun EventTarget.progressindicator(op: ProgressIndicator.() -> Unit = {}) = opcr(this, ProgressIndicator(), op)
+fun EventTarget.progressindicator(property: Property<Number>, op: ProgressIndicator.() -> Unit = {}) = progressindicator().apply {
     bind(property)
-    op?.invoke(this)
+    op(this)
 }
 
-fun EventTarget.progressbar(initialValue: Double? = null, op: (ProgressBar.() -> Unit)? = null) = opcr(this, ProgressBar().apply { if (initialValue != null) progress = initialValue }, op)
-fun EventTarget.progressbar(property: ObservableValue<Number>, op: (ProgressBar.() -> Unit)? = null) = progressbar().apply {
+fun EventTarget.progressbar(initialValue: Double? = null, op: ProgressBar.() -> Unit = {}) = opcr(this, ProgressBar().apply { if (initialValue != null) progress = initialValue }, op)
+fun EventTarget.progressbar(property: ObservableValue<Number>, op: ProgressBar.() -> Unit = {}) = progressbar().apply {
     bind(property)
-    op?.invoke(this)
+    op(this)
 }
 
-fun EventTarget.slider(min: Number? = null, max: Number? = null, value: Number? = null, orientation: Orientation? = null, op: (Slider.() -> Unit)? = null) = opcr(this, Slider().apply {
+fun EventTarget.slider(min: Number? = null, max: Number? = null, value: Number? = null, orientation: Orientation? = null, op: Slider.() -> Unit= {}) = opcr(this, Slider().apply {
     if (min != null) this.min = min.toDouble()
     if (max != null) this.max = max.toDouble()
     if (value != null) this.value = value.toDouble()
@@ -308,56 +154,53 @@ fun EventTarget.slider(min: Number? = null, max: Number? = null, value: Number? 
 }, op)
 
 // Buttons
-fun EventTarget.button(text: String = "", graphic: Node? = null, op: (Button.() -> Unit)? = null): Button {
+fun EventTarget.button(text: String = "", graphic: Node? = null, op: Button.() -> Unit = {}): Button {
     val button = Button(text)
     if (graphic != null) button.graphic = graphic
     return opcr(this, button, op)
 }
 
-fun EventTarget.menubutton(text: String = "", graphic: Node? = null, op: (MenuButton.() -> Unit)? = null): MenuButton {
+fun EventTarget.menubutton(text: String = "", graphic: Node? = null, op: MenuButton.() -> Unit = {}): MenuButton {
     val button = MenuButton(text)
     if (graphic != null) button.graphic = graphic
     return opcr(this, button, op)
 }
 
-fun EventTarget.button(text: ObservableValue<String>, graphic: Node? = null, op: (Button.() -> Unit)? = null): Button {
+fun EventTarget.button(text: ObservableValue<String>, graphic: Node? = null, op: Button.() -> Unit = {}): Button {
     val button = Button()
     button.textProperty().bind(text)
     if (graphic != null) button.graphic = graphic
     return opcr(this, button, op)
 }
 
-fun ToolBar.button(text: String = "", graphic: Node? = null, op: (Button.() -> Unit)? = null): Button {
+fun ToolBar.button(text: String = "", graphic: Node? = null, op: Button.() -> Unit = {}): Button {
     val button = Button(text)
     if (graphic != null)
         button.graphic = graphic
     items.add(button)
-    op?.invoke(button)
-    return button
+    return button.also(op)
 }
 
-fun ToolBar.button(text: ObservableValue<String>, graphic: Node? = null, op: (Button.() -> Unit)? = null): Button {
+fun ToolBar.button(text: ObservableValue<String>, graphic: Node? = null, op: Button.() -> Unit = {}): Button {
     val button = Button()
     button.textProperty().bind(text)
     if (graphic != null)
         button.graphic = graphic
     items.add(button)
-    op?.invoke(button)
-    return button
+    return button.also(op)
 }
 
-fun ButtonBar.button(text: String = "", type: ButtonBar.ButtonData? = null, graphic: Node? = null, op: (Button.() -> Unit)? = null): Button {
+fun ButtonBar.button(text: String = "", type: ButtonBar.ButtonData? = null, graphic: Node? = null, op: Button.() -> Unit = {}): Button {
     val button = Button(text)
     if (type != null)
         ButtonBar.setButtonData(button, type)
     if (graphic != null)
         button.graphic = graphic
     buttons.add(button)
-    op?.invoke(button)
-    return button
+    return button.also(op)
 }
 
-fun ButtonBar.button(text: ObservableValue<String>, type: ButtonBar.ButtonData? = null, graphic: Node? = null, op: (Button.() -> Unit)? = null): Button {
+fun ButtonBar.button(text: ObservableValue<String>, type: ButtonBar.ButtonData? = null, graphic: Node? = null, op: Button.() -> Unit = {}): Button {
     val button = Button()
     button.textProperty().bind(text)
     if (type != null)
@@ -365,15 +208,13 @@ fun ButtonBar.button(text: ObservableValue<String>, type: ButtonBar.ButtonData? 
     if (graphic != null)
         button.graphic = graphic
     buttons.add(button)
-    op?.invoke(button)
-    return button
+    return button.also(op)
 }
 
-fun Node.togglegroup(op: (ToggleGroup.() -> Unit)? = null): ToggleGroup {
+fun Node.togglegroup(op: ToggleGroup.() -> Unit = {}): ToggleGroup {
     val group = ToggleGroup()
     properties["tornadofx.togglegroup"] = group
-    op?.invoke(group)
-    return group
+    return group.also(op)
 }
 
 /**
@@ -417,7 +258,7 @@ fun <T> ToggleGroup.selectedValueProperty(): ObjectProperty<T> =
  * Likewise, if the `selectedValueProperty` of the ToggleGroup is updated to a value that matches the value for this
  * togglebutton, it will be automatically selected.
  */
-fun Node.togglebutton(text: String? = null, group: ToggleGroup? = getToggleGroup(), selectFirst: Boolean = true, value: Any? = null, op: (ToggleButton.() -> Unit)? = null) =
+fun Node.togglebutton(text: String? = null, group: ToggleGroup? = getToggleGroup(), selectFirst: Boolean = true, value: Any? = null, op: ToggleButton.() -> Unit = {}) =
         opcr(this, ToggleButton().apply {
             this.text = if (value != null && text == null) value.toString() else text ?: ""
             properties["tornadofx.toggleGroupValue"] = value ?: text
@@ -437,20 +278,20 @@ fun ToggleButton.whenSelected(op: () -> Unit) {
  * Likewise, if the `selectedValueProperty` of the ToggleGroup is updated to a value that matches the value for this
  * radiobutton, it will be automatically selected.
  */
-fun Node.radiobutton(text: String? = null, group: ToggleGroup? = getToggleGroup(), value: Any? = null, op: (RadioButton.() -> Unit)? = null)
+fun Node.radiobutton(text: String? = null, group: ToggleGroup? = getToggleGroup(), value: Any? = null, op: RadioButton.() -> Unit = {})
         = opcr(this, RadioButton().apply {
     this.text = if (value != null && text == null) value.toString() else text ?: ""
     properties["tornadofx.toggleGroupValue"] = value ?: text
     if (group != null) toggleGroup = group
 }, op)
 
-fun EventTarget.label(text: String = "", graphic: Node? = null, op: (Label.() -> Unit)? = null): Label {
+fun EventTarget.label(text: String = "", graphic: Node? = null, op: Label.() -> Unit = {}): Label {
     val label = Label(text)
     if (graphic != null) label.graphic = graphic
     return opcr(this, label, op)
 }
 
-inline fun <reified T> EventTarget.label(observable: ObservableValue<T>, graphicProperty: ObjectProperty<Node>? = null, converter: StringConverter<in T>? = null, noinline op: (Label.() -> Unit)? = null) = label().apply {
+inline fun <reified T> EventTarget.label(observable: ObservableValue<T>, graphicProperty: ObjectProperty<Node>? = null, converter: StringConverter<in T>? = null, noinline op: Label.() -> Unit = {}) = label().apply {
     if (converter == null) {
         if (T::class == String::class) {
             @Suppress("UNCHECKED_CAST")
@@ -462,27 +303,27 @@ inline fun <reified T> EventTarget.label(observable: ObservableValue<T>, graphic
         textProperty().bind(observable.stringBinding { converter.toString(it) })
     }
     if (graphic != null) graphicProperty().bind(graphicProperty)
-    op?.invoke(this)
+    op(this)
 }
 
-fun EventTarget.hyperlink(text: String = "", graphic: Node? = null, op: (Hyperlink.() -> Unit)? = null) = opcr(this, Hyperlink(text, graphic), op)
-fun EventTarget.hyperlink(observable: ObservableValue<String>, graphic: Node? = null, op: (Hyperlink.() -> Unit)? = null) = hyperlink(graphic = graphic).apply {
+fun EventTarget.hyperlink(text: String = "", graphic: Node? = null, op: Hyperlink.() -> Unit = {}) = opcr(this, Hyperlink(text, graphic), op)
+fun EventTarget.hyperlink(observable: ObservableValue<String>, graphic: Node? = null, op: Hyperlink.() -> Unit = {}) = hyperlink(graphic = graphic).apply {
     bind(observable)
-    op?.invoke(this)
+    op(this)
 }
 
-fun EventTarget.menubar(op: (MenuBar.() -> Unit)? = null) = opcr(this, MenuBar(), op)
+fun EventTarget.menubar(op: MenuBar.() -> Unit = {}) = opcr(this, MenuBar(), op)
 
-fun EventTarget.imageview(url: String? = null, lazyload: Boolean = true, op: (ImageView.() -> Unit)? = null)
+fun EventTarget.imageview(url: String? = null, lazyload: Boolean = true, op: ImageView.() -> Unit = {})
         = opcr(this, if (url == null) ImageView() else ImageView(Image(url, lazyload)), op)
 
-fun EventTarget.imageview(url: ObservableValue<String>, lazyload: Boolean = true, op: (ImageView.() -> Unit)? = null)
+fun EventTarget.imageview(url: ObservableValue<String>, lazyload: Boolean = true, op: ImageView.() -> Unit = {})
         = opcr(this, ImageView().apply { imageProperty().bind(objectBinding(url) { value?.let { Image(it, lazyload) } }) }, op)
 
-fun EventTarget.imageview(image: ObservableValue<Image?>, op: (ImageView.() -> Unit)? = null)
+fun EventTarget.imageview(image: ObservableValue<Image?>, op: ImageView.() -> Unit = {})
         = opcr(this, ImageView().apply { imageProperty().bind(image) }, op)
 
-fun EventTarget.imageview(image: Image, op: (ImageView.() -> Unit)? = null)
+fun EventTarget.imageview(image: Image, op: ImageView.() -> Unit = {})
         = opcr(this, ImageView(image), op)
 
 /**

--- a/src/main/java/tornadofx/DataGrid.ktx
+++ b/src/main/java/tornadofx/DataGrid.ktx
@@ -7,9 +7,7 @@ import com.sun.javafx.scene.control.behavior.CellBehaviorBase
 import com.sun.javafx.scene.control.skin.CellSkinBase
 import com.sun.javafx.scene.control.skin.VirtualContainerBase
 import javafx.beans.InvalidationListener
-import javafx.beans.property.Property
-import javafx.beans.property.SimpleListProperty
-import javafx.beans.property.SimpleObjectProperty
+import javafx.beans.property.*
 import javafx.beans.value.ChangeListener
 import javafx.beans.value.ObservableValue
 import javafx.collections.FXCollections
@@ -18,21 +16,80 @@ import javafx.collections.ObservableList
 import javafx.collections.WeakListChangeListener
 import javafx.css.*
 import javafx.event.EventTarget
+import javafx.geometry.Pos
 import javafx.scene.Node
 import javafx.scene.control.*
 import javafx.scene.control.SelectionMode.MULTIPLE
 import javafx.scene.control.SelectionMode.SINGLE
-import javafx.scene.control.skin.VirtualContainerBase
 import javafx.scene.input.*
+import javafx.scene.layout.HBox
 import javafx.scene.layout.StackPane
-import java.awt.SystemColor.control
+import java.util.*
+import kotlin.reflect.KClass
 
-fun <T> EventTarget.datagrid(items: List<T>? = null, op: (DataGrid<T>.() -> Unit)? = null): DataGrid<T> {
+fun <T> EventTarget.datagrid(items: List<T>? = null, scope: Scope = DefaultScope, op: DataGrid<T>.() -> Unit = {}): DataGrid<T> {
     val datagrid = DataGrid<T>()
+    datagrid.scope = scope
     if (items is ObservableList<T>) datagrid.items = items
     else if (items is List<T>) datagrid.items.setAll(items)
     opcr(this, datagrid, op)
     return datagrid
+}
+
+class DataGridPaginator<T>(private val sourceItems: ObservableList<T>, itemsPerPage: Int = 20): HBox() {
+    val itemsPerPageProperty = SimpleIntegerProperty(itemsPerPage)
+    var itemsPerPage by  itemsPerPageProperty
+
+    val items = FXCollections.observableArrayList<T>()
+
+    private val listChangeTrigger = SimpleObjectProperty(UUID.randomUUID())
+
+    val pageCountProperty = integerBinding(itemsPerPageProperty, sourceItems) {
+        Math.max(1, Math.ceil(sourceItems.size.toDouble() / itemsPerPageProperty.value.toDouble()).toInt())
+    }
+    val pageCount by pageCountProperty
+
+    val currentPageProperty = SimpleIntegerProperty(1)
+    var currentPage by currentPageProperty
+
+    private val listChangeListener = ListChangeListener<T> {
+        listChangeTrigger.value = UUID.randomUUID()
+        setItemsForPage()
+
+        // Check that the current page is still valid, or regenerate buttons
+        while (currentPage > pageCount)
+            currentPage -= 1
+    }
+
+    private val currentFromIndex: Int get() = itemsPerPage * (currentPage - 1)
+    private val currentToIndex: Int get() = Math.min(currentFromIndex + itemsPerPage, sourceItems.size)
+
+    init {
+        spacing = 5.0
+        alignment = Pos.CENTER
+        currentPageProperty.onChange { setItemsForPage() }
+        pageCountProperty.onChange { generatePageButtons() }
+        sourceItems.addListener(listChangeListener)
+        generatePageButtons()
+        setItemsForPage()
+    }
+
+    private fun setItemsForPage() {
+        items.setAll(sourceItems.subList(currentFromIndex, currentToIndex))
+    }
+
+    private fun generatePageButtons() {
+        children.clear()
+        togglegroup {
+            // TODO: Support pagination for pages
+            IntRange(1, pageCount).forEach { pageNo ->
+                // TODO: Allow customization of togglebutton graphic/text
+                togglebutton(pageNo.toString()) {
+                    whenSelected { currentPage = pageNo }
+                }
+            }
+        }
+    }
 }
 
 @Suppress("unused")
@@ -56,10 +113,22 @@ class DataGrid<T>(items: ObservableList<T>) : Control() {
         this.cellFormat = cellFormat
     }
 
+    val scopeProperty = SimpleObjectProperty<Scope>()
+    var scope: Scope? by scopeProperty
+
     val cellCacheProperty by lazy { SimpleObjectProperty<((T) -> Node)>() }
     var cellCache: ((T) -> Node)? get() = cellCacheProperty.get(); set(value) = cellCacheProperty.set(value)
     fun cellCache(cachedGraphic: (T) -> Node) {
         this.cellCache = cachedGraphic
+    }
+
+    val cellFragmentProperty by lazy { SimpleObjectProperty<KClass<DataGridCellFragment<T>>>() }
+    var cellFragment by cellFragmentProperty
+    fun cellFragment(fragment: KClass<DataGridCellFragment<T>>) {
+        properties["tornadofx.cellFragment"] = fragment
+    }
+    inline fun <reified C : DataGridCellFragment<T>> cellFragment() {
+        properties["tornadofx.cellFragment"] = C::class
     }
 
     val cellWidthProperty: StyleableObjectProperty<Number> = FACTORY.createStyleableNumberProperty(this, "cellWidth", "-fx-cell-width", { it.cellWidthProperty }, 150.0) as StyleableObjectProperty<Number>
@@ -156,14 +225,17 @@ class DataGrid<T>(items: ObservableList<T>) : Control() {
 open class DataGridCell<T>(val dataGrid: DataGrid<T>) : IndexedCell<T>() {
     var cache: Node? = null
     var updating = false
+    private var fresh = true
+    private var cellFragment: DataGridCellFragment<T>? = null
 
     init {
         addClass(Stylesheet.datagridCell)
 
         // Update cell content when index changes
-        indexProperty().addListener(InvalidationListener {
+        indexProperty().onChange {
+            if (it == -1) clearCellFragment()
             if (!updating) doUpdateItem()
-        })
+        }
     }
 
     internal fun doUpdateItem() {
@@ -186,9 +258,69 @@ open class DataGridCell<T>(val dataGrid: DataGrid<T>) : IndexedCell<T>() {
         else if (isSelected && !isActuallySelected) updateSelected(false)
     }
 
+    override fun updateItem(item: T?, empty: Boolean) {
+        super.updateItem(item, empty)
+        if (item == null || empty) {
+            graphic = null
+            text = null
+            clearCellFragment()
+        } else {
+            val formatter = dataGrid.cellFormat
+            if (fresh) {
+                val cellFragmentType = dataGrid.properties["tornadofx.cellFragment"] as KClass<DataGridCellFragment<T>>?
+                cellFragment = if (cellFragmentType != null) find(cellFragmentType, dataGrid.scope ?: DefaultScope) else null
+                fresh = false
+            }
+            cellFragment?.apply {
+                editingProperty.cleanBind(editingProperty())
+                itemProperty.value = item
+                cellProperty.value = this@DataGridCell
+                graphic = root
+            }
+            if (cache != null) {
+                graphic = StackPane(cache)
+                formatter?.invoke(this, item)
+            } else {
+                if (formatter != null) formatter.invoke(this, item)
+                else if (graphic == null) graphic = StackPane(Label(item.toString()))
+            }
+        }
+    }
+
+    private fun clearCellFragment() {
+        cellFragment?.apply {
+            cellProperty.value = null
+            itemProperty.value = null
+            editingProperty.unbind()
+            editingProperty.value = false
+        }
+    }
+
     override fun createDefaultSkin() = DataGridCellSkin(this)
 }
 
+abstract class DataGridCellFragment<T> : ItemFragment<T>() {
+    val cellProperty: ObjectProperty<DataGridCell<T>?> = SimpleObjectProperty()
+    var cell by cellProperty
+    val editingProperty = SimpleBooleanProperty(false)
+    val editing by editingProperty
+
+    open fun startEdit() {
+        cell?.startEdit()
+    }
+
+    open fun commitEdit(newValue: T) {
+        cell?.commitEdit(newValue)
+    }
+
+    open fun cancelEdit() {
+        cell?.cancelEdit()
+    }
+
+    open fun onEdit(op: () -> Unit) {
+        editingProperty.onChange { if (it) op() }
+    }
+}
 
 class DataGridCellBehavior<T>(control: DataGridCell<T>) : CellBehaviorBase<DataGridCell<T>>(control, emptyList()) {
     override fun getFocusModel() = control.dataGrid.focusModel
@@ -288,29 +420,10 @@ class DataGridRowSkin<T>(control: DataGridRow<T>) : CellSkinBase<DataGridRow<T>,
             // this one, we need to remove the extra cells that remain
             children.remove(cacheIndex, children.size)
         }
-
     }
 
-    private fun createCell() = skinnable.dataGrid.cellFactory?.invoke(skinnable.dataGrid) ?: createDefaultCell()
+    private fun createCell() = skinnable.dataGrid.cellFactory?.invoke(skinnable.dataGrid) ?: DataGridCell<T>(skinnable.dataGrid)
 
-    private fun createDefaultCell() = object : DataGridCell<T>(skinnable.dataGrid) {
-        override fun updateItem(item: T?, empty: Boolean) {
-            super.updateItem(item, empty)
-            if (item == null || empty) {
-                graphic = null
-                text = null
-            } else {
-                val formatter = skinnable.dataGrid.cellFormat
-                if (cache != null) {
-                    graphic = StackPane(cache)
-                    formatter?.invoke(this, item)
-                } else {
-                    if (formatter != null) formatter.invoke(this, item)
-                    else graphic = StackPane(Label(item.toString()))
-                }
-            }
-        }
-    }
 
     @Suppress("UNCHECKED_CAST")
     fun getCellAtIndex(index: Int): DataGridCell<T>? {
@@ -502,7 +615,7 @@ class DataGridSelectionModel<T>(val dataGrid: DataGrid<T>) : MultipleSelectionMo
 }
 
 @Suppress("UNCHECKED_CAST")
-class DataGridSkin<T>(control: DataGrid<T>) : VirtualContainerBase<DataGrid<T>, IndexedCell<T>() {
+class DataGridSkin<T>(control: DataGrid<T>) : VirtualContainerBase<DataGrid<T>, BehaviorBase<DataGrid<T>>, DataGridRow<T>>(control, BehaviorBase(control, emptyList())) {
     private val gridViewItemsListener = ListChangeListener<T> {
         updateRowCount()
         skinnable.requestLayout()

--- a/src/main/java/tornadofx/Dialogs.kt
+++ b/src/main/java/tornadofx/Dialogs.kt
@@ -8,14 +8,16 @@ import javafx.stage.FileChooser
 import javafx.stage.Stage
 import javafx.stage.Window
 import tornadofx.FileChooserMode.*
+import tornadofx.Stylesheet.Companion.title
+import tornadofx.WizardStyles.Companion.buttons
 import java.io.File
 
 /**
  * Show a confirmation dialog and execute the given action if confirmButton is clicked. The button types
  * of the confirmButton and cancelButton are configurable.
  */
-fun confirm(header: String, content: String = "", confirmButton: ButtonType = ButtonType.OK, cancelButton: ButtonType = ButtonType.CANCEL, actionFn: () -> Unit) {
-    alert(Alert.AlertType.CONFIRMATION, header, content, *arrayOf(confirmButton, cancelButton)) {
+fun confirm(header: String, content: String = "", confirmButton: ButtonType = ButtonType.OK, cancelButton: ButtonType = ButtonType.CANCEL, owner: Window? = null, title: String? = null, actionFn: () -> Unit) {
+    alert(Alert.AlertType.CONFIRMATION, header, content, confirmButton, cancelButton, owner = owner, title = title) {
         if (it == confirmButton) actionFn()
     }
 }
@@ -33,27 +35,29 @@ fun alert(type: Alert.AlertType,
           content: String? = null,
           vararg buttons: ButtonType,
           owner: Window? = null,
-          actionFn: (Alert.(ButtonType) -> Unit)? = null): Alert {
+          title: String? = null,
+          actionFn: Alert.(ButtonType) -> Unit = {}): Alert {
 
     val alert = Alert(type, content ?: "", *buttons)
+    title?.let { alert.title = it }
     alert.headerText = header
     owner?.also { alert.initOwner(it) }
     val buttonClicked = alert.showAndWait()
-    buttonClicked.ifPresent { actionFn?.invoke(alert, buttonClicked.get()) }
+    buttonClicked.ifPresent { actionFn(alert, buttonClicked.get()) }
     return alert
 }
 
-fun warning(header: String, content: String? = null, vararg buttons: ButtonType, actionFn: (Alert.(ButtonType) -> Unit)? = null) =
-        alert(Alert.AlertType.WARNING, header, content, *buttons, actionFn = actionFn)
+fun warning(header: String, content: String? = null, vararg buttons: ButtonType, owner: Window? = null, title: String? = null, actionFn: Alert.(ButtonType) -> Unit = {}) =
+        alert(Alert.AlertType.WARNING, header, content, *buttons, owner = owner, title = title, actionFn = actionFn)
 
-fun error(header: String, content: String? = null, vararg buttons: ButtonType, actionFn: (Alert.(ButtonType) -> Unit)? = null) =
-        alert(Alert.AlertType.ERROR, header, content, *buttons, actionFn = actionFn)
+fun error(header: String, content: String? = null, vararg buttons: ButtonType, owner: Window? = null, title: String? = null, actionFn: Alert.(ButtonType) -> Unit = {}) =
+        alert(Alert.AlertType.ERROR, header, content, *buttons, owner = owner, title = title, actionFn = actionFn)
 
-fun information(header: String, content: String? = null, vararg buttons: ButtonType, actionFn: (Alert.(ButtonType) -> Unit)? = null) =
-        alert(Alert.AlertType.INFORMATION, header, content, *buttons, actionFn = actionFn)
+fun information(header: String, content: String? = null, vararg buttons: ButtonType, owner: Window? = null, title: String? = null, actionFn: Alert.(ButtonType) -> Unit = {}) =
+        alert(Alert.AlertType.INFORMATION, header, content, *buttons, owner = owner, title = title, actionFn = actionFn)
 
-fun confirmation(header: String, content: String? = null, vararg buttons: ButtonType, actionFn: (Alert.(ButtonType) -> Unit)? = null) =
-        alert(Alert.AlertType.CONFIRMATION, header, content, *buttons, actionFn = actionFn)
+fun confirmation(header: String, content: String? = null, vararg buttons: ButtonType, owner: Window? = null, title: String? = null, actionFn: Alert.(ButtonType) -> Unit = {}) =
+        alert(Alert.AlertType.CONFIRMATION, header, content, *buttons, owner = owner, title = title, actionFn = actionFn)
 
 enum class FileChooserMode { None, Single, Multi, Save }
 
@@ -66,11 +70,11 @@ enum class FileChooserMode { None, Single, Multi, Save }
  *
  * If the user cancels, the returnedfile list will be empty.
  */
-fun chooseFile(title: String? = null, filters: Array<FileChooser.ExtensionFilter>, mode: FileChooserMode = Single, owner: Window? = null, op: (FileChooser.() -> Unit)? = null): List<File> {
+fun chooseFile(title: String? = null, filters: Array<FileChooser.ExtensionFilter>, mode: FileChooserMode = Single, owner: Window? = null, op: FileChooser.() -> Unit = {}): List<File> {
     val chooser = FileChooser()
     if (title != null) chooser.title = title
     chooser.extensionFilters.addAll(filters)
-    op?.invoke(chooser)
+    op(chooser)
     return when (mode) {
         Single -> {
             val result = chooser.showOpenDialog(owner)
@@ -85,11 +89,11 @@ fun chooseFile(title: String? = null, filters: Array<FileChooser.ExtensionFilter
     }
 }
 
-fun chooseDirectory(title: String? = null, initialDirectory: File? = null, owner: Window? = null, op: (DirectoryChooser.() -> Unit)? = null): File? {
+fun chooseDirectory(title: String? = null, initialDirectory: File? = null, owner: Window? = null, op: DirectoryChooser.() -> Unit = {}): File? {
     val chooser = DirectoryChooser()
     if (title != null) chooser.title = title
     if (initialDirectory != null) chooser.initialDirectory = initialDirectory
-    op?.invoke(chooser)
+    op(chooser)
     return chooser.showDialog(owner)
 }
 

--- a/src/main/java/tornadofx/Drawer.kt
+++ b/src/main/java/tornadofx/Drawer.kt
@@ -2,6 +2,7 @@
 
 package tornadofx
 
+import com.sun.org.apache.bcel.internal.Repository.addClass
 import javafx.beans.property.*
 import javafx.beans.value.ObservableValue
 import javafx.collections.FXCollections
@@ -17,6 +18,12 @@ import javafx.scene.layout.BorderPane
 import javafx.scene.layout.Priority
 import javafx.scene.layout.VBox
 import javafx.scene.paint.Color
+import tornadofx.DrawerStyles.Companion.buttonArea
+import tornadofx.DrawerStyles.Companion.contentArea
+import tornadofx.Stylesheet.Companion.bottom
+import tornadofx.Stylesheet.Companion.contextMenu
+import tornadofx.Stylesheet.Companion.left
+import tornadofx.Stylesheet.Companion.right
 
 fun EventTarget.drawer(side: Side = Side.LEFT, multiselect: Boolean = false, floatingContent: Boolean = false, op: Drawer.() -> Unit) = opcr(this, Drawer(side, multiselect, floatingContent), op)
 
@@ -48,11 +55,10 @@ class Drawer(side: Side, multiselect: Boolean, floatingContent: Boolean) : Borde
     fun item(title: String? = null, icon: Node? = null, expanded: Boolean = false, showHeader: Boolean = multiselect, op: DrawerItem.() -> Unit) =
             item(SimpleStringProperty(title), SimpleObjectProperty(icon), expanded, showHeader, op)
 
-    fun item(uiComponent: UIComponent, expanded: Boolean = false, showHeader: Boolean = multiselect, op: (DrawerItem.() -> Unit)? = null): DrawerItem {
-        val item = DrawerItem(this, uiComponent.titleProperty, uiComponent.iconProperty, showHeader)
-        item.button.textProperty().bind(uiComponent.headingProperty)
-        item.children.add(uiComponent.root)
-        op?.invoke(item)
+    fun item(title: ObservableValue<String?>, icon: ObservableValue<Node?>? = null, expanded: Boolean = multiselect, showHeader: Boolean = true, op: DrawerItem.() -> Unit): DrawerItem {
+        val item = DrawerItem(this, title, icon, showHeader)
+        item.button.textProperty().bind(title)
+        op(item)
         items.add(item)
         if (expanded) item.button.isSelected = true
         (parent?.uiComponent<UIComponent>() as? Workspace)?.apply {
@@ -63,9 +69,10 @@ class Drawer(side: Side, multiselect: Boolean, floatingContent: Boolean) : Borde
         return item
     }
 
-    fun item(title: ObservableValue<String?>, icon: ObservableValue<Node?>? = null, expanded: Boolean = multiselect, showHeader: Boolean = true, op: DrawerItem.() -> Unit): DrawerItem {
-        val item = DrawerItem(this, title, icon, showHeader)
-        item.button.textProperty().bind(title)
+    fun item(uiComponent: UIComponent, expanded: Boolean = false, showHeader: Boolean = multiselect, op: DrawerItem.() -> Unit = {}): DrawerItem {
+        val item = DrawerItem(this, uiComponent.titleProperty, uiComponent.iconProperty, showHeader)
+        item.button.textProperty().bind(uiComponent.headingProperty)
+        item.children.add(uiComponent.root)
         op(item)
         items.add(item)
         if (expanded) item.button.isSelected = true

--- a/src/main/java/tornadofx/Drawer.kt
+++ b/src/main/java/tornadofx/Drawer.kt
@@ -2,7 +2,6 @@
 
 package tornadofx
 
-import com.sun.org.apache.bcel.internal.Repository.addClass
 import javafx.beans.property.*
 import javafx.beans.value.ObservableValue
 import javafx.collections.FXCollections
@@ -18,12 +17,6 @@ import javafx.scene.layout.BorderPane
 import javafx.scene.layout.Priority
 import javafx.scene.layout.VBox
 import javafx.scene.paint.Color
-import tornadofx.DrawerStyles.Companion.buttonArea
-import tornadofx.DrawerStyles.Companion.contentArea
-import tornadofx.Stylesheet.Companion.bottom
-import tornadofx.Stylesheet.Companion.contextMenu
-import tornadofx.Stylesheet.Companion.left
-import tornadofx.Stylesheet.Companion.right
 
 fun EventTarget.drawer(side: Side = Side.LEFT, multiselect: Boolean = false, floatingContent: Boolean = false, op: Drawer.() -> Unit) = opcr(this, Drawer(side, multiselect, floatingContent), op)
 

--- a/src/main/java/tornadofx/Forms.kt
+++ b/src/main/java/tornadofx/Forms.kt
@@ -20,9 +20,9 @@ import javafx.stage.Stage
 import java.util.*
 import java.util.concurrent.Callable
 
-fun EventTarget.form(op: (Form.() -> Unit)? = null) = opcr(this, Form(), op)
+fun EventTarget.form(op: Form.() -> Unit = {}) = opcr(this, Form(), op)
 
-fun EventTarget.fieldset(text: String? = null, icon: Node? = null, labelPosition: Orientation? = null, wrapWidth: Double? = null, op: (Fieldset.() -> Unit)? = null): Fieldset {
+fun EventTarget.fieldset(text: String? = null, icon: Node? = null, labelPosition: Orientation? = null, wrapWidth: Double? = null, op: Fieldset.() -> Unit = {}): Fieldset {
     val fieldset = Fieldset(text ?: "")
     if (wrapWidth != null) fieldset.wrapWidth = wrapWidth
     if (labelPosition != null) fieldset.labelPosition = labelPosition
@@ -34,10 +34,10 @@ fun EventTarget.fieldset(text: String? = null, icon: Node? = null, labelPosition
 /**
  *  Creates a ButtonBarFiled with the given button order (refer to [javafx.scene.control.ButtonBar#buttonOrderProperty()] for more information about buttonOrder).
  */
-fun EventTarget.buttonbar(buttonOrder: String? = null, forceLabelIndent: Boolean = true, op: (ButtonBar.() -> Unit)? = null): ButtonBarField {
+fun EventTarget.buttonbar(buttonOrder: String? = null, forceLabelIndent: Boolean = true, op: ButtonBar.() -> Unit = {}): ButtonBarField {
     val field = ButtonBarField(buttonOrder, forceLabelIndent)
-    opcr(this, field, null)
-    op?.invoke(field.inputContainer)
+    opcr(this, field){}
+    op(field.inputContainer)
     return field
 }
 
@@ -50,10 +50,10 @@ fun EventTarget.buttonbar(buttonOrder: String? = null, forceLabelIndent: Boolean
  *
  * @see buttonbar
  */
-fun EventTarget.field(text: String? = null, orientation: Orientation = HORIZONTAL, forceLabelIndent: Boolean = false, op: (Field.() -> Unit)? = null): Field {
+fun EventTarget.field(text: String? = null, orientation: Orientation = HORIZONTAL, forceLabelIndent: Boolean = false, op: Field.() -> Unit = {}): Field {
     val field = Field(text ?: "", orientation, forceLabelIndent)
-    opcr(this, field, null)
-    op?.invoke(field)
+    opcr(this, field){}
+    op(field)
     return field
 }
 
@@ -245,10 +245,10 @@ class Field(text: String? = null, orientation: Orientation = HORIZONTAL, forceLa
 
 @DefaultProperty("inputs")
 abstract class AbstractField(text: String? = null, val forceLabelIndent: Boolean = false) : Pane() {
-    val textProperty = SimpleStringProperty(text)
-    var text by textProperty
+    val labelProperty = SimpleStringProperty(text)
     @Deprecated("Please use the new more concise syntax.", ReplaceWith("textProperty"), DeprecationLevel.WARNING)
-    fun textProperty() = textProperty
+    fun textProperty() = labelProperty
+    var text by labelProperty
 
     val label = Label()
     val labelContainer = HBox(label).apply { addClass(Stylesheet.labelContainer) }
@@ -260,14 +260,14 @@ abstract class AbstractField(text: String? = null, val forceLabelIndent: Boolean
     init {
         isFocusTraversable = false
         addClass(Stylesheet.field)
-        label.textProperty().bind(textProperty)
+        label.textProperty().bind(labelProperty)
         children.add(labelContainer)
     }
 
     val fieldset: Fieldset get() = findParent()!!
 
     override fun computePrefHeight(width: Double): Double {
-        val labelHasContent = forceLabelIndent || !text.isNullOrBlank()
+        val labelHasContent = forceLabelIndent || !labelProperty.value.isNullOrBlank()
 
         val labelHeight = if (labelHasContent) labelContainer.prefHeight(width) else 0.0
         val inputHeight = inputContainer.prefHeight(width)
@@ -282,7 +282,7 @@ abstract class AbstractField(text: String? = null, val forceLabelIndent: Boolean
 
     override fun computePrefWidth(height: Double): Double {
         val fieldset = fieldset
-        val labelHasContent = forceLabelIndent || !text.isNullOrBlank()
+        val labelHasContent = forceLabelIndent || !labelProperty.value.isNullOrBlank()
 
         val labelWidth = if (labelHasContent) fieldset.form.labelContainerWidth(height) else 0.0
         val inputWidth = inputContainer.prefWidth(height)
@@ -299,7 +299,7 @@ abstract class AbstractField(text: String? = null, val forceLabelIndent: Boolean
 
     override fun layoutChildren() {
         val fieldset = fieldset
-        val labelHasContent = forceLabelIndent || !text.isNullOrBlank()
+        val labelHasContent = forceLabelIndent || !labelProperty.value.isNullOrBlank()
 
         val insets = insets
         val contentX = insets.left

--- a/src/main/java/tornadofx/ItemControls.kt
+++ b/src/main/java/tornadofx/ItemControls.kt
@@ -2,9 +2,6 @@
 
 package tornadofx
 
-import com.sun.corba.se.impl.util.RepositoryId.cache
-import com.sun.javafx.scene.control.skin.TableRowSkin
-import com.sun.org.apache.bcel.internal.Repository.addClass
 import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.beans.Observable
@@ -24,6 +21,7 @@ import javafx.geometry.Pos
 import javafx.scene.Node
 import javafx.scene.control.*
 import javafx.scene.control.cell.*
+import javafx.scene.control.skin.TableRowSkinBase
 import javafx.scene.input.MouseEvent
 import javafx.scene.layout.StackPane
 import javafx.scene.paint.Color
@@ -31,10 +29,6 @@ import javafx.scene.shape.Polygon
 import javafx.scene.text.Text
 import javafx.util.Callback
 import javafx.util.StringConverter
-import tornadofx.Stylesheet.Companion.editable
-import tornadofx.Stylesheet.Companion.root
-import tornadofx.Stylesheet.Companion.title
-import tornadofx.WizardStyles.Companion.graphic
 import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction
@@ -837,7 +831,23 @@ class ExpanderColumn<S>(private val expandedNodeCallback: RowExpanderPane.(S) ->
     }
 }
 
-class ExpandableTableRowSkin<S>(val tableRow: TableRow<S>, val expander: ExpanderColumn<S>) : TableRowSkin<S>(tableRow) {
+class ExpandableTableRowSkin<S>(val tableRow: TableRow<S>, val expander: ExpanderColumn<S>) : TableRowSkinBase<S, TableRow<S>, TableCell<S,*>>(tableRow) {
+    override fun getVisibleLeafColumns(): ObservableList<out TableColumnBase<Any, Any>> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createCell(tc: TableColumnBase<S, *>?): TableCell<S, *> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun updateCell(cell: TableCell<S, *>?, row: TableRow<S>?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getTableColumn(cell: TableCell<S, *>?): TableColumnBase<S, *> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
     var tableRowPrefHeight = -1.0
 
     init {
@@ -1110,10 +1120,27 @@ class TableColumnDirtyState<S>(val editModel: TableViewEditModel<S>, val item: S
 }
 
 @Suppress("UNCHECKED_CAST")
-class DirtyDecoratingTableRowSkin<S>(tableRow: TableRow<S>, val editModel: TableViewEditModel<S>) : TableRowSkin<S>(tableRow) {
-    private fun getPolygon(cell: TableCell<S, *>) =
+class DirtyDecoratingTableRowSkin<T>(tableRow: TableRow<T>, val editModel: TableViewEditModel<T>) : TableRowSkinBase<T, TableRow<T>, TableCell<T,*>>(tableRow) {
+    override fun getVisibleLeafColumns(): ObservableList<out TableColumnBase<Any, Any>> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun updateCell(cell: TableCell<T, *>?, row: TableRow<T>?) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun getTableColumn(cell: TableCell<T, *>?): TableColumnBase<T, *> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun createCell(tc: TableColumnBase<T, *>?): TableCell<T, *> {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    private fun getPolygon(cell: TableCell<T, *>) =
             cell.properties.getOrPut("tornadofx.dirtyStatePolygon") { Polygon(0.0, 0.0, 0.0, 10.0, 10.0, 0.0).apply { fill = Color.BLUE } } as Polygon
 
+    /*
     override fun layoutChildren(x: Double, y: Double, w: Double, h: Double) {
         super.layoutChildren(x, y, w, h)
 
@@ -1131,7 +1158,7 @@ class DirtyDecoratingTableRowSkin<S>(tableRow: TableRow<S>, val editModel: Table
             }
         }
 
-    }
+    }*/
 }
 
 /**

--- a/src/main/java/tornadofx/Keyboard.kt
+++ b/src/main/java/tornadofx/Keyboard.kt
@@ -136,9 +136,9 @@ class KeyboardRow(val keyboard: KeyboardLayout) {
         keys.add(this)
     }
 
-    fun key(text: String? = null, svg: String? = null, code: Int? = null, width: Number = 1.0, height: Number = 1.0, op: (KeyboardKey.() -> Unit)? = null): KeyboardKey {
+    fun key(text: String? = null, svg: String? = null, code: Int? = null, width: Number = 1.0, height: Number = 1.0, op: KeyboardKey.() -> Unit = {}): KeyboardKey {
         val key = KeyboardKey(keyboard, text, svg, code, width, height)
-        op?.invoke(key)
+        op(key)
         keys.add(key)
         return key
     }

--- a/src/main/java/tornadofx/LayoutDebugger.kt
+++ b/src/main/java/tornadofx/LayoutDebugger.kt
@@ -214,6 +214,9 @@ class LayoutDebugger : Fragment() {
             field("StyleClass") {
                 text(node.styleClass.joinToString(", ") { ".$it" })
             }
+            field("Id") {
+                text(node.id ?: "")
+            }
         }
         fieldset("Dimensions") {
             fun Bounds.describe() = "(${minX.toInt()}, ${width.toInt()}), (${minY.toInt()}, ${height.toInt()})"

--- a/src/main/java/tornadofx/Layouts.kt
+++ b/src/main/java/tornadofx/Layouts.kt
@@ -2,6 +2,7 @@ package tornadofx
 
 import javafx.beans.property.ObjectProperty
 import javafx.beans.value.ObservableValue
+import javafx.collections.ObservableList
 import javafx.event.EventTarget
 import javafx.geometry.Insets
 import javafx.geometry.Orientation
@@ -14,74 +15,77 @@ import javafx.scene.control.*
 import javafx.scene.layout.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KFunction1
+import kotlin.reflect.full.createInstance
 
 private val GridPaneRowIdKey = "TornadoFX.GridPaneRowId"
 private val GridPaneParentObjectKey = "TornadoFX.GridPaneParentObject"
 
-fun GridPane.row(title: String? = null, op: (Pane.() -> Unit)? = null) {
+fun GridPane.row(title: String? = null, op: Pane.() -> Unit = {}) {
     properties[GridPaneRowIdKey] = if (properties.containsKey(GridPaneRowIdKey)) properties[GridPaneRowIdKey] as Int + 1 else 0
 
     // Allow the caller to add children to a fake pane
     val fake = Pane()
     fake.properties[GridPaneParentObjectKey] = this
-    if (title != null)
-        fake.children.add(Label(title))
+    if (title != null) fake.children.add(Label(title))
 
-    op?.invoke(fake)
+    op(fake)
 
     // Create a new row in the GridPane and add the children added to the fake pane
     addRow(properties[GridPaneRowIdKey] as Int, *fake.children.toTypedArray())
 }
 
-fun GridPane.constraintsForColumn(columnIndex: Int): ColumnConstraints {
-    val constraints = columnConstraints
-    while (constraints.size <= columnIndex)
-        constraints.add(ColumnConstraints())
-    return constraints[columnIndex]
+fun GridPane.constraintsForColumn(columnIndex: Int) = constraintsFor(columnConstraints, columnIndex)
+
+fun GridPane.constraintsForRow(rowIndex: Int) = constraintsFor(rowConstraints, rowIndex)
+
+//constraints for row and column can be handled the same way
+internal inline fun <reified T : ConstraintsBase> constraintsFor(constraints: ObservableList<T>, index: Int): T {
+    while (constraints.size <= index) constraints.add(T::class.createInstance())
+    return constraints[index]
 }
 
-val Parent.gridpaneColumnConstraints: ColumnConstraints? get() {
-    var cursor = this
-    var next = parent
-    while (next != null) {
-        val gridReference = if (next is GridPane)
-            next to GridPane.getColumnIndex(cursor)?.let { it }
-        else if (next.parent == null) // perhaps we're still in the row builder
-            (next.properties[GridPaneParentObjectKey] as? GridPane)?.let {
-                it to next.getChildList()?.indexOf(cursor)
+val Parent.gridpaneColumnConstraints: ColumnConstraints?
+    get() {
+        var cursor = this
+        var next = parent
+        while (next != null) {
+            val gridReference = when {
+                next is GridPane -> next to GridPane.getColumnIndex(cursor)?.let { it }
+            // perhaps we're still in the row builder
+                next.parent == null -> (next.properties[GridPaneParentObjectKey] as? GridPane)?.let {
+                    it to next.getChildList()?.indexOf(cursor)
+                }
+                else -> null
             }
-        else null
 
-        if (gridReference != null) {
-            val (grid, columnIndex) = gridReference
-            if (columnIndex != null && columnIndex >= 0)
-                return grid.constraintsForColumn(columnIndex)
+            if (gridReference != null) {
+                val (grid, columnIndex) = gridReference
+                if (columnIndex != null && columnIndex >= 0) return grid.constraintsForColumn(columnIndex)
+            }
+            cursor = next
+            next = next.parent
         }
-        cursor = next
-        next = next.parent
+        return null
     }
-    return null
-}
 
 fun Parent.gridpaneColumnConstraints(op: ColumnConstraints.() -> Unit) = gridpaneColumnConstraints?.apply { op() }
 
-fun ToolBar.spacer(prio: Priority = Priority.ALWAYS, op: (Pane.() -> Unit)? = null): Pane {
+fun ToolBar.spacer(prio: Priority = Priority.ALWAYS, op: Pane.() -> Unit = {}): Pane {
     val pane = Pane().apply {
         addClass("spacer")
         hgrow = prio
     }
-    op?.invoke(pane)
+    op(pane)
     add(pane)
     return pane
 }
 
-fun HBox.spacer(prio: Priority = Priority.ALWAYS, op: (Pane.() -> Unit)? = null) = opcr(this, Pane().apply { HBox.setHgrow(this, prio) }, op)
-fun VBox.spacer(prio: Priority = Priority.ALWAYS, op: (Pane.() -> Unit)? = null) = opcr(this, Pane().apply { VBox.setVgrow(this, prio) }, op)
+fun HBox.spacer(prio: Priority = Priority.ALWAYS, op: Pane.() -> Unit = {}) = opcr(this, Pane().apply { HBox.setHgrow(this, prio) }, op)
+fun VBox.spacer(prio: Priority = Priority.ALWAYS, op: Pane.() -> Unit = {}) = opcr(this, Pane().apply { VBox.setVgrow(this, prio) }, op)
 
-fun EventTarget.toolbar(vararg nodes: Node, op: (ToolBar.() -> Unit)? = null): ToolBar {
+fun EventTarget.toolbar(vararg nodes: Node, op: ToolBar.() -> Unit = {}): ToolBar {
     val toolbar = ToolBar()
-    if (nodes.isNotEmpty())
-        toolbar.items.addAll(nodes)
+    if (nodes.isNotEmpty()) toolbar.items.addAll(nodes)
     opcr(this, toolbar, op)
     return toolbar
 }
@@ -90,41 +94,42 @@ fun EventTarget.toolbar(vararg nodes: Node, op: (ToolBar.() -> Unit)? = null): T
 @Deprecated("No need to wrap ToolBar children in children{} anymore. Remove the wrapper and all builder items will still be added as before.", ReplaceWith("no children{} wrapper"), DeprecationLevel.WARNING)
 fun ToolBar.children(op: ToolBar.() -> Unit) = apply { op() }
 
-fun EventTarget.hbox(spacing: Number? = null, alignment: Pos? = null, op: (HBox.() -> Unit)? = null): HBox {
+fun EventTarget.hbox(spacing: Number? = null, alignment: Pos? = null, op: HBox.() -> Unit = {}): HBox {
     val hbox = HBox()
     if (alignment != null) hbox.alignment = alignment
     if (spacing != null) hbox.spacing = spacing.toDouble()
     return opcr(this, hbox, op)
 }
 
-fun EventTarget.vbox(spacing: Number? = null, alignment: Pos? = null, op: (VBox.() -> Unit)? = null): VBox {
+fun EventTarget.vbox(spacing: Number? = null, alignment: Pos? = null, op: VBox.() -> Unit = {}): VBox {
     val vbox = VBox()
     if (alignment != null) vbox.alignment = alignment
     if (spacing != null) vbox.spacing = spacing.toDouble()
     return opcr(this, vbox, op)
 }
 
-fun ToolBar.separator(orientation: Orientation = Orientation.HORIZONTAL, op: (Separator.() -> Unit)? = null): Separator {
-    val separator = Separator(orientation)
-    op?.invoke(separator)
+fun ToolBar.separator(orientation: Orientation = Orientation.HORIZONTAL, op: Separator.() -> Unit = {}): Separator {
+    val separator = Separator(orientation).also(op)
     add(separator)
     return separator
 }
 
-fun EventTarget.separator(orientation: Orientation = Orientation.HORIZONTAL, op: (Separator.() -> Unit)? = null) = opcr(this, Separator(orientation), op)
+fun EventTarget.separator(orientation: Orientation = Orientation.HORIZONTAL, op: Separator.() -> Unit = {}) = opcr(this, Separator(orientation), op)
 
-fun EventTarget.group(initialChildren: Iterable<Node>? = null, op: (Group.() -> Unit)? = null) = opcr(this, Group().apply { if (initialChildren != null) children.addAll(initialChildren) }, op)
-fun EventTarget.stackpane(initialChildren: Iterable<Node>? = null, op: (StackPane.() -> Unit)? = null) = opcr(this, StackPane().apply { if (initialChildren != null) children.addAll(initialChildren) }, op)
-fun EventTarget.gridpane(op: (GridPane.() -> Unit)? = null) = opcr(this, GridPane(), op)
-fun EventTarget.pane(op: (Pane.() -> Unit)? = null) = opcr(this, Pane(), op)
-fun EventTarget.flowpane(op: (FlowPane.() -> Unit)? = null) = opcr(this, FlowPane(), op)
-fun EventTarget.tilepane(op: (TilePane.() -> Unit)? = null) = opcr(this, TilePane(), op)
-fun EventTarget.borderpane(op: (BorderPane.() -> Unit)? = null) = opcr(this, BorderPane(), op)
+fun EventTarget.group(initialChildren: Iterable<Node>? = null, op: Group.() -> Unit = {}) = opcr(this, Group().apply { if (initialChildren != null) children.addAll(initialChildren) }, op)
+fun EventTarget.stackpane(initialChildren: Iterable<Node>? = null, op: StackPane.() -> Unit = {}) = opcr(this, StackPane().apply { if (initialChildren != null) children.addAll(initialChildren) }, op)
+fun EventTarget.gridpane(op: GridPane.() -> Unit = {}) = opcr(this, GridPane(), op)
+fun EventTarget.pane(op: Pane.() -> Unit = {}) = opcr(this, Pane(), op)
+fun EventTarget.flowpane(op: FlowPane.() -> Unit = {}) = opcr(this, FlowPane(), op)
+fun EventTarget.tilepane(op: TilePane.() -> Unit = {}) = opcr(this, TilePane(), op)
+fun EventTarget.borderpane(op: BorderPane.() -> Unit = {}) = opcr(this, BorderPane(), op)
 
 @Suppress("UNCHECKED_CAST")
-var Node.builderTarget : KFunction1<*, ObjectProperty<Node>>?
+var Node.builderTarget: KFunction1<*, ObjectProperty<Node>>?
     get() = properties["tornadofx.builderTarget"] as KFunction1<Any, ObjectProperty<Node>>?
-    set(value) { properties["tornadofx.builderTarget"] = value }
+    set(value) {
+        properties["tornadofx.builderTarget"] = value
+    }
 
 fun BorderPane.top(op: BorderPane.() -> Unit) = region(BorderPane::topProperty, op)
 fun BorderPane.bottom(op: BorderPane.() -> Unit) = region(BorderPane::bottomProperty, op)
@@ -138,51 +143,51 @@ internal fun BorderPane.region(region: KFunction1<BorderPane, ObjectProperty<Nod
 }
 
 @Deprecated("Use top = node {} instead")
-fun <T : Node> BorderPane.top(topNode: T, op: (T.() -> Unit)? = null): T {
+fun <T : Node> BorderPane.top(topNode: T, op: T.() -> Unit = {}): T {
     top = topNode
     return opcr(this, topNode, op)
 }
 
-inline fun <reified C: UIComponent> BorderPane.setRegion(scope: Scope, region: KFunction1<BorderPane, ObjectProperty<Node>>) = apply {
+inline fun <reified C : UIComponent> BorderPane.setRegion(scope: Scope, region: KFunction1<BorderPane, ObjectProperty<Node>>) = apply {
     region.invoke(this).value = find<C>(scope).root
 }
 
-fun <C: UIComponent> BorderPane.setRegion(scope: Scope, region: KFunction1<BorderPane, ObjectProperty<Node>>, nodeType: KClass<C>) = apply {
+fun <C : UIComponent> BorderPane.setRegion(scope: Scope, region: KFunction1<BorderPane, ObjectProperty<Node>>, nodeType: KClass<C>) = apply {
     region.invoke(this).value = find(nodeType, scope).root
 }
 
 @Deprecated("Use bottom = node {} instead")
-fun <T : Node> BorderPane.bottom(bottomNode: T, op: (T.() -> Unit)? = null): T {
+fun <T : Node> BorderPane.bottom(bottomNode: T, op: T.() -> Unit = {}): T {
     bottom = bottomNode
     return opcr(this, bottomNode, op)
 }
 
 @Deprecated("Use left = node {} instead")
-fun <T : Node> BorderPane.left(leftNode: T, op: (T.() -> Unit)? = null): T {
+fun <T : Node> BorderPane.left(leftNode: T, op: T.() -> Unit = {}): T {
     left = leftNode
     return opcr(this, leftNode, op)
 }
 
 @Deprecated("Use right = node {} instead")
-fun <T : Node> BorderPane.right(rightNode: T, op: (T.() -> Unit)? = null): T {
+fun <T : Node> BorderPane.right(rightNode: T, op: T.() -> Unit = {}): T {
     right = rightNode
     return opcr(this, rightNode, op)
 }
 
 @Deprecated("Use center = node {} instead")
-fun <T : Node> BorderPane.center(centerNode: T, op: (T.() -> Unit)? = null): T {
+fun <T : Node> BorderPane.center(centerNode: T, op: T.() -> Unit = {}): T {
     center = centerNode
     return opcr(this, centerNode, op)
 }
 
-fun EventTarget.titledpane(title: String? = null, node: Node? = null, collapsible: Boolean = true, op: ((TitledPane).() -> Unit)? = null): TitledPane {
+fun EventTarget.titledpane(title: String? = null, node: Node? = null, collapsible: Boolean = true, op: (TitledPane).() -> Unit = {}): TitledPane {
     val titledPane = TitledPane(title, node)
     titledPane.isCollapsible = collapsible
     opcr(this, titledPane, op)
     return titledPane
 }
 
-fun EventTarget.titledpane(title: ObservableValue<String>, node: Node? = null, collapsible: Boolean = true, op: ((TitledPane).() -> Unit)? = null): TitledPane {
+fun EventTarget.titledpane(title: ObservableValue<String>, node: Node? = null, collapsible: Boolean = true, op: (TitledPane).() -> Unit = {}): TitledPane {
     val titledPane = TitledPane("", node)
     titledPane.textProperty().bind(title)
     titledPane.isCollapsible = collapsible
@@ -190,14 +195,14 @@ fun EventTarget.titledpane(title: ObservableValue<String>, node: Node? = null, c
     return titledPane
 }
 
-fun EventTarget.pagination(pageCount: Int? = null, pageIndex: Int? = null, op: (Pagination.() -> Unit)? = null): Pagination {
+fun EventTarget.pagination(pageCount: Int? = null, pageIndex: Int? = null, op: Pagination.() -> Unit = {}): Pagination {
     val pagination = Pagination()
     if (pageCount != null) pagination.pageCount = pageCount
     if (pageIndex != null) pagination.currentPageIndex = pageIndex
     return opcr(this, pagination, op)
 }
 
-fun EventTarget.scrollpane(fitToWidth: Boolean = false, fitToHeight: Boolean = false, op: (ScrollPane.() -> Unit)? = null): ScrollPane {
+fun EventTarget.scrollpane(fitToWidth: Boolean = false, fitToHeight: Boolean = false, op: ScrollPane.() -> Unit = {}): ScrollPane {
     val pane = ScrollPane()
     pane.isFitToWidth = fitToWidth
     pane.isFitToHeight = fitToHeight
@@ -205,11 +210,13 @@ fun EventTarget.scrollpane(fitToWidth: Boolean = false, fitToHeight: Boolean = f
     return pane
 }
 
-var ScrollPane.edgeToEdge: Boolean get() = hasClass("edge-to-edge"); set(value) {
-    if (value) addClass("edge-to-edge") else removeClass("edge-to-edge")
-}
+var ScrollPane.edgeToEdge: Boolean
+    get() = hasClass("edge-to-edge")
+    set(value) {
+        if (value) addClass("edge-to-edge") else removeClass("edge-to-edge")
+    }
 
-fun EventTarget.splitpane(orientation: Orientation = Orientation.HORIZONTAL, vararg nodes: Node, op: (SplitPane.() -> Unit)? = null): SplitPane {
+fun EventTarget.splitpane(orientation: Orientation = Orientation.HORIZONTAL, vararg nodes: Node, op: SplitPane.() -> Unit = {}): SplitPane {
     val splitpane = SplitPane()
     splitpane.orientation = orientation
     if (nodes.isNotEmpty())
@@ -221,77 +228,84 @@ fun EventTarget.splitpane(orientation: Orientation = Orientation.HORIZONTAL, var
 @Deprecated("No need to wrap splitpane items in items{} anymore. Remove the wrapper and all builder items will still be added as before.", ReplaceWith("no items{} wrapper"), DeprecationLevel.WARNING)
 fun SplitPane.items(op: (SplitPane.() -> Unit)) = op(this)
 
-fun EventTarget.canvas(width: Double = 0.0, height: Double = 0.0, op: (Canvas.() -> Unit)? = null) =
+fun EventTarget.canvas(width: Double = 0.0, height: Double = 0.0, op: Canvas.() -> Unit = {}) =
         opcr(this, Canvas(width, height), op)
 
-fun EventTarget.anchorpane(vararg nodes: Node, op: (AnchorPane.() -> Unit)? = null): AnchorPane {
+fun EventTarget.anchorpane(vararg nodes: Node, op: AnchorPane.() -> Unit = {}): AnchorPane {
     val anchorpane = AnchorPane()
     if (nodes.isNotEmpty()) anchorpane.children.addAll(nodes)
     opcr(this, anchorpane, op)
     return anchorpane
 }
 
-fun EventTarget.accordion(vararg panes: TitledPane, op: (Accordion.() -> Unit)? = null): Accordion {
+fun EventTarget.accordion(vararg panes: TitledPane, op: Accordion.() -> Unit = {}): Accordion {
     val accordion = Accordion()
     if (panes.isNotEmpty()) accordion.panes.addAll(panes)
     opcr(this, accordion, op)
     return accordion
 }
 
-fun <T : Node> Accordion.fold(title: String? = null, node: T, expanded: Boolean = false, op: (T.() -> Unit)? = null): TitledPane {
+fun <T : Node> Accordion.fold(title: String? = null, node: T, expanded: Boolean = false, op: T.() -> Unit = {}): TitledPane {
     val fold = TitledPane(title, node)
     fold.isExpanded = expanded
     panes += fold
-    op?.invoke(node)
+    op(node)
     return fold
 }
 
 @Deprecated("Properties added to the container will be lost if you add only a single child Node", ReplaceWith("Accordion.fold(title, node, op)"), DeprecationLevel.WARNING)
-fun Accordion.fold(title: String? = null, op: (Pane.() -> Unit)? = null): TitledPane {
-    val vbox = VBox()
-    op?.invoke(vbox)
+fun Accordion.fold(title: String? = null, op: Pane.() -> Unit = {}): TitledPane {
+    val vbox = VBox().also(op)
     val fold = TitledPane(title, if (vbox.children.size == 1) vbox.children[0] else vbox)
     panes += fold
     return fold
 }
 
-fun EventTarget.region(op: (Region.() -> Unit)? = null) = opcr(this, Region(), op)
+fun EventTarget.region(op: Region.() -> Unit = {}) = opcr(this, Region(), op)
 
 @Deprecated("Use the paddingRight property instead", ReplaceWith("paddingRight = p"))
 fun Region.paddingRight(p: Double) {
     padding = Insets(padding.top, p, padding.bottom, padding.left)
 }
 
-var Region.paddingRight: Number get() = padding.right; set(value) {
-    padding = Insets(padding.top, value.toDouble(), padding.bottom, padding.left)
-}
+var Region.paddingRight: Number
+    get() = padding.right
+    set(value) {
+        padding = Insets(padding.top, value.toDouble(), padding.bottom, padding.left)
+    }
 
 @Deprecated("Use the paddingLeft property instead", ReplaceWith("paddingLeft = p"))
 fun Region.paddingLeft(p: Double) {
     padding = Insets(padding.top, padding.right, padding.bottom, p)
 }
 
-var Region.paddingLeft: Number get() = padding.left; set(value) {
-    padding = Insets(padding.top, padding.right, padding.bottom, value.toDouble())
-}
+var Region.paddingLeft: Number
+    get() = padding.left
+    set(value) {
+        padding = Insets(padding.top, padding.right, padding.bottom, value.toDouble())
+    }
 
 @Deprecated("Use the paddingTop property instead", ReplaceWith("paddingTop = p"))
 fun Region.paddingTop(p: Double) {
     padding = Insets(p, padding.right, padding.bottom, padding.left)
 }
 
-var Region.paddingTop: Number get() = padding.top; set(value) {
-    padding = Insets(value.toDouble(), padding.right, padding.bottom, padding.left)
-}
+var Region.paddingTop: Number
+    get() = padding.top
+    set(value) {
+        padding = Insets(value.toDouble(), padding.right, padding.bottom, padding.left)
+    }
 
 @Deprecated("Use the paddingBottom property instead", ReplaceWith("paddingBottom = p"))
 fun Region.paddingBottom(p: Double) {
     padding = Insets(padding.top, padding.right, p, padding.left)
 }
 
-var Region.paddingBottom: Number get() = padding.bottom; set(value) {
-    padding = Insets(padding.top, padding.right, value.toDouble(), padding.left)
-}
+var Region.paddingBottom: Number
+    get() = padding.bottom
+    set(value) {
+        padding = Insets(padding.top, padding.right, value.toDouble(), padding.left)
+    }
 
 @Deprecated("Use the paddingVertical property instead", ReplaceWith("paddingVertical = p"))
 fun Region.paddingVertical(p: Double) {
@@ -299,10 +313,12 @@ fun Region.paddingVertical(p: Double) {
     padding = Insets(half, padding.right, half, padding.left)
 }
 
-var Region.paddingVertical: Number get() = (padding.top + padding.bottom) / 2.0; set(value) {
-    val half = value.toDouble() / 2.0
-    padding = Insets(half, padding.right, half, padding.left)
-}
+var Region.paddingVertical: Number
+    get() = (padding.top + padding.bottom) / 2.0
+    set(value) {
+        val half = value.toDouble() / 2.0
+        padding = Insets(half, padding.right, half, padding.left)
+    }
 
 @Deprecated("Use the paddingHorizontal property instead", ReplaceWith("paddingHorizontal = p"))
 fun Region.paddingHorizontal(p: Double) {
@@ -310,16 +326,52 @@ fun Region.paddingHorizontal(p: Double) {
     padding = Insets(padding.top, half, padding.bottom, half)
 }
 
-var Region.paddingHorizontal: Number get() = (padding.left + padding.right) / 2.0; set(value) {
-    val half = value.toDouble() / 2.0
-    padding = Insets(padding.top, half, padding.bottom, half)
-}
+var Region.paddingHorizontal: Number
+    get() = (padding.left + padding.right) / 2.0
+    set(value) {
+        val half = value.toDouble() / 2.0
+        padding = Insets(padding.top, half, padding.bottom, half)
+    }
 
 @Deprecated("Use the paddingAll property instead", ReplaceWith("paddingAll = p"))
 fun Region.paddingAll(p: Double) {
     padding = Insets(p, p, p, p)
 }
 
-var Region.paddingAll: Number get() = (padding.top + padding.right + padding.bottom + padding.left) / 4.0; set(value) {
-    padding = Insets(value.toDouble(), value.toDouble(), value.toDouble(), value.toDouble())
+var Region.paddingAll: Number
+    get() = (padding.top + padding.right + padding.bottom + padding.left) / 4.0
+    set(value) {
+        padding = Insets(value.toDouble(), value.toDouble(), value.toDouble(), value.toDouble())
+    }
+
+fun Region.fitToParentHeight() {
+    val parent = this.parent
+    if (parent != null && parent is Region) {
+        fitToHeight(parent)
+    }
+}
+
+fun Region.fitToParentWidth() {
+    val parent = this.parent
+    if (parent != null && parent is Region) {
+        fitToWidth(parent)
+    }
+}
+
+fun Region.fitToParentSize() {
+    fitToParentHeight()
+    fitToParentWidth()
+}
+
+fun Region.fitToHeight(region: Region) {
+    minHeightProperty().bind(region.heightProperty())
+}
+
+fun Region.fitToWidth(region: Region) {
+    minWidthProperty().bind(region.widthProperty())
+}
+
+fun Region.fitToSize(region: Region) {
+    fitToHeight(region)
+    fitToWidth(region)
 }

--- a/src/main/java/tornadofx/Lib.kt
+++ b/src/main/java/tornadofx/Lib.kt
@@ -2,14 +2,12 @@
 
 package tornadofx
 
-import javafx.application.Platform
 import javafx.beans.InvalidationListener
 import javafx.beans.property.*
 import javafx.beans.value.*
 import javafx.collections.*
 import javafx.collections.transformation.FilteredList
 import javafx.collections.transformation.SortedList
-import javafx.concurrent.Task
 import javafx.geometry.Insets
 import javafx.scene.control.ListView
 import javafx.scene.control.TableView
@@ -210,76 +208,6 @@ fun <T> List<T>.observable(): ObservableList<T> = FXCollections.observableList(t
 fun <T> Set<T>.observable(): ObservableSet<T> = FXCollections.observableSet(this)
 fun <K, V> Map<K, V>.observable(): ObservableMap<K, V> = FXCollections.observableMap(this)
 
-class FXTask<T>(val status: TaskStatus? = null, val func: FXTask<*>.() -> T) : Task<T>() {
-    val completedProperty: ReadOnlyBooleanProperty = SimpleBooleanProperty(false)
-    val completed by completedProperty
-
-    override fun call() = func(this)
-
-    init {
-        status?.item = this
-    }
-
-    override fun succeeded() {
-        (completedProperty as BooleanProperty).value = true
-    }
-
-    override fun failed() {
-        (completedProperty as BooleanProperty).value = true
-    }
-
-    override fun cancelled() {
-        (completedProperty as BooleanProperty).value = true
-    }
-
-    override public fun updateProgress(workDone: Long, max: Long) {
-        super.updateProgress(workDone, max)
-    }
-
-    override public fun updateProgress(workDone: Double, max: Double) {
-        super.updateProgress(workDone, max)
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    fun value(v: Any) {
-        super.updateValue(v as T)
-    }
-
-    override public fun updateTitle(t: String?) {
-        super.updateTitle(t)
-    }
-
-    override public fun updateMessage(m: String?) {
-        super.updateMessage(m)
-    }
-
-}
-
-open class TaskStatus : ItemViewModel<FXTask<*>>() {
-    val running: ReadOnlyBooleanProperty = bind { SimpleBooleanProperty().apply { if (item != null) bind(item.runningProperty()) } }
-    val completed: ReadOnlyBooleanProperty = bind { SimpleBooleanProperty().apply { if (item != null) bind(item.completedProperty) } }
-    val message: ReadOnlyStringProperty = bind { SimpleStringProperty().apply { if (item != null) bind(item.messageProperty()) } }
-    val title: ReadOnlyStringProperty = bind { SimpleStringProperty().apply { if (item != null) bind(item.titleProperty()) } }
-    val progress: ReadOnlyDoubleProperty = bind { SimpleDoubleProperty().apply { if (item != null) bind(item.progressProperty()) } }
-}
-
-fun <T> task(taskStatus: TaskStatus? = null, func: FXTask<*>.() -> T): Task<T> = FXTask(taskStatus, func = func).apply {
-    setOnFailed({ Thread.getDefaultUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), exception) })
-    Thread(this).start()
-}
-
-infix fun <T> Task<T>.success(func: (T) -> Unit) = apply {
-    Platform.runLater {
-        setOnSucceeded { func(value) }
-    }
-}
-
-infix fun <T> Task<T>.fail(func: (Throwable) -> Unit) = apply {
-    Platform.runLater {
-        setOnFailed { func(exception) }
-    }
-}
-
 fun Clipboard.setContent(op: ClipboardContent.() -> Unit) {
     val content = ClipboardContent()
     op(content)
@@ -367,3 +295,8 @@ fun <R> proxypropDouble(receiver: Property<R>, getter: Property<R>.() -> Double,
 fun insets(all: Number) = Insets(all.toDouble(), all.toDouble(), all.toDouble(), all.toDouble())
 fun insets(horizontal: Number? = null, vertical: Number? = null) = Insets(vertical?.toDouble() ?: 0.0, horizontal?.toDouble() ?: 0.0, vertical?.toDouble() ?: 0.0, horizontal?.toDouble() ?: 0.0)
 fun insets(top: Number? = null, right: Number? = null, bottom: Number? = null, left: Number? = null) = Insets(top?.toDouble() ?: 0.0, right?.toDouble() ?: 0.0, bottom?.toDouble() ?: 0.0, left?.toDouble() ?: 0.0)
+
+fun String.isLong() = toLongOrNull() != null
+fun String.isInt() = toIntOrNull() != null
+fun String.isDouble() = toDoubleOrNull() != null
+fun String.isFloat() = toFloatOrNull() != null

--- a/src/main/java/tornadofx/ListMenu.kt
+++ b/src/main/java/tornadofx/ListMenu.kt
@@ -18,6 +18,7 @@ import javafx.scene.image.ImageView
 import javafx.scene.input.MouseEvent
 import javafx.scene.layout.Region
 import javafx.scene.text.Text
+import tornadofx.WizardStyles.Companion.graphic
 
 @DefaultProperty("children")
 class ListMenu : Control() {
@@ -79,7 +80,7 @@ class ListMenu : Control() {
 
     override fun getUserAgentStylesheet(): String = ListMenu::class.java.getResource("listmenu.css").toExternalForm()
 
-    fun item(text: String? = null, graphic: Node? = null, tag: Any? = null, op :(ListMenuItem.() -> Unit)? = null): ListMenuItem {
+    fun item(text: String? = null, graphic: Node? = null, tag: Any? = null, op :ListMenuItem.() -> Unit = {}): ListMenuItem {
         val item = ListMenuItem(text ?: tag?.toString(), graphic)
         item.tag = tag
         return opcr(this, item, op)
@@ -316,7 +317,7 @@ class ListMenuItemSkin(control: ListMenuItem) : SkinBase<ListMenuItem>(control) 
     private val graphicFixedSize: Double get() = skinnable.menu.graphicFixedSizeProperty.value.toDouble()
 }
 
-fun EventTarget.listmenu(orientation: Orientation = VERTICAL, iconPosition: Side = Side.LEFT, theme: String? = null, tag: Any? = null, op: (ListMenu.() -> Unit)? = null): ListMenu {
+fun EventTarget.listmenu(orientation: Orientation = VERTICAL, iconPosition: Side = Side.LEFT, theme: String? = null, tag: Any? = null, op: ListMenu.() -> Unit = {}): ListMenu {
     val listmenu = ListMenu().apply {
         this.orientation = orientation
         this.iconPosition = iconPosition

--- a/src/main/java/tornadofx/ListView.kt
+++ b/src/main/java/tornadofx/ListView.kt
@@ -9,6 +9,8 @@ import javafx.collections.ObservableMap
 import javafx.scene.Node
 import javafx.scene.control.ListCell
 import javafx.scene.control.ListView
+import javafx.scene.control.SelectionMode
+import javafx.scene.control.TableView
 import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyEvent
 import javafx.scene.input.MouseEvent
@@ -93,7 +95,7 @@ open class SmartListCell<T>(val scope: Scope = DefaultScope, listView: ListView<
      */
     constructor(scope: Scope = DefaultScope, properties : Map<Any,Any>? = null) : this(scope, null, properties)
 
-    private val smartProperties: ObservableMap<Any, Any> = listView?.properties ?: HashMap(properties.orEmpty()).observable()
+    private val smartProperties: ObservableMap<Any,Any> = listView?.properties ?: HashMap(properties.orEmpty()).observable()
     private val editSupport: (ListCell<T>.(EditEventType, T?) -> Unit)? get() = smartProperties["tornadofx.editSupport"] as (ListCell<T>.(EditEventType, T?) -> Unit)?
     private val cellFormat: (ListCell<T>.(T) -> Unit)? get() = smartProperties["tornadofx.cellFormat"] as (ListCell<T>.(T) -> Unit)?
     private val cellCache: ListCellCache<T>? get() = smartProperties["tornadofx.cellCache"] as ListCellCache<T>?
@@ -210,4 +212,8 @@ fun <T> ListView<T>.cellCache(scope: Scope = DefaultScope, cachedGraphicProvider
     if (properties["tornadofx.cellCacheCapable"] != true) {
         cellFormat(scope) { }
     }
+}
+
+fun <T> ListView<T>.multiSelect(enable: Boolean = true) {
+    selectionModel.selectionMode = if (enable) SelectionMode.MULTIPLE else SelectionMode.SINGLE
 }

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -1,11 +1,14 @@
 package tornadofx
 
+import javafx.beans.property.Property
 import javafx.beans.value.ObservableValue
 import javafx.event.ActionEvent
 import javafx.event.EventTarget
 import javafx.scene.Node
 import javafx.scene.control.*
 import javafx.scene.input.KeyCombination
+import tornadofx.Stylesheet.Companion.contextMenu
+import tornadofx.WizardStyles.Companion.graphic
 
 //Menu-related operator functions
 operator fun <T : MenuItem> Menu.plusAssign(menuItem: T) {
@@ -21,17 +24,15 @@ operator fun <T : MenuItem> ContextMenu.plusAssign(menuItem: T) {
 }
 
 //MenuBar extensions
-fun MenuBar.menu(name: String? = null, graphic: Node? = null, op: (Menu.() -> Unit)? = null): Menu {
-    val menu = Menu(name, graphic)
-    op?.invoke(menu)
+fun MenuBar.menu(name: String? = null, graphic: Node? = null, op: Menu.() -> Unit = {}): Menu {
+    val menu = Menu(name, graphic).also(op)
     this += menu
     return menu
 }
 
 //ContextMenu extensions
-fun ContextMenu.menu(name: String? = null, op: (Menu.() -> Unit)? = null): Menu {
-    val menu = Menu(name)
-    op?.invoke(menu)
+fun ContextMenu.menu(name: String? = null, op: Menu.() -> Unit = {}): Menu {
+    val menu = Menu(name).also(op)
     this += menu
     return menu
 }
@@ -41,15 +42,15 @@ fun ContextMenu.menu(name: String? = null, op: (Menu.() -> Unit)? = null): Menu 
  * op block operates on the MenuItem. This deprecation was made to align the menuitem builder with the other builders.
  */
 @Deprecated("Use the item builder instead, which expects an action parameter", ReplaceWith("item(name, KeyCombination.valueOf(keyCombination), graphic).action(onAction)"))
-fun ContextMenu.menuitem(name: String, keyCombination: String, graphic: Node? = null, onAction: (() -> Unit)? = null): MenuItem {
-    return this.item(name, KeyCombination.valueOf(keyCombination), graphic).apply { if (onAction != null) action(onAction) }
+fun ContextMenu.menuitem(name: String, keyCombination: String, graphic: Node? = null, onAction: () -> Unit = {}): MenuItem {
+    return this.item(name, KeyCombination.valueOf(keyCombination), graphic).apply { action(onAction) }
 }
 
-fun ContextMenu.checkmenuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (CheckMenuItem.() -> Unit)? = null): CheckMenuItem {
+fun ContextMenu.checkmenuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: CheckMenuItem.() -> Unit = {}): CheckMenuItem {
     val checkMenuItem = CheckMenuItem(name, graphic)
     keyCombination?.apply { checkMenuItem.accelerator = this }
     graphic?.apply { checkMenuItem.graphic = graphic }
-    op?.invoke(checkMenuItem)
+    op(checkMenuItem)
     this += checkMenuItem
     return checkMenuItem
 }
@@ -59,11 +60,11 @@ fun ContextMenu.checkmenuitem(name: String, keyCombination: KeyCombination? = nu
  * op block operates on the MenuItem. This deprecation was made to align the menuitem builder with the other builders.
  */
 @Deprecated("Use the item builder instead, which expects an action parameter", ReplaceWith("item(name, keyCombination, graphic).action(onAction)"))
-fun ContextMenu.menuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, onAction: ((ActionEvent) -> Unit)? = null): MenuItem {
+fun ContextMenu.menuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, onAction: (ActionEvent) -> Unit = {}): MenuItem {
     val menuItem = MenuItem(name, graphic)
     keyCombination?.apply { menuItem.accelerator = this }
     graphic?.apply { menuItem.graphic = this }
-    onAction?.apply { menuItem.setOnAction { onAction.invoke(it) } }
+    menuItem.setOnAction(onAction)
     this += menuItem
     return menuItem
 }
@@ -72,11 +73,11 @@ fun ContextMenu.menuitem(name: String, keyCombination: KeyCombination? = null, g
  * Create a MenuItem. The op block operates on the MenuItem where you can call `setOnAction` to provide the menu item action. Notice that this differs
  * from the deprecated `menuitem` builder where the op is configured as the `setOnAction` directly.
  */
-fun ContextMenu.item(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (MenuItem.() -> Unit)? = null): MenuItem {
+fun ContextMenu.item(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: MenuItem.() -> Unit = {}): MenuItem {
     val menuItem = MenuItem(name, graphic)
     keyCombination?.apply { menuItem.accelerator = this }
     graphic?.apply { menuItem.graphic = this }
-    op?.invoke(menuItem)
+    op(menuItem)
     this += menuItem
     return menuItem
 }
@@ -86,12 +87,12 @@ fun ContextMenu.item(name: String, keyCombination: KeyCombination? = null, graph
  * call `setOnAction` to provide the menu item action. Notice that this differs from the deprecated `menuitem` builder where the op
  * is configured as the `setOnAction` directly.
  */
-fun ContextMenu.item(name: ObservableValue<String>, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (MenuItem.() -> Unit)? = null): MenuItem {
+fun ContextMenu.item(name: ObservableValue<String>, keyCombination: KeyCombination? = null, graphic: Node? = null, op: MenuItem.() -> Unit = {}): MenuItem {
     val menuItem = MenuItem(null, graphic)
     menuItem.textProperty().bind(name)
     keyCombination?.apply { menuItem.accelerator = this }
     graphic?.apply { menuItem.graphic = this }
-    op?.invoke(menuItem)
+    op(menuItem)
     this += menuItem
     return menuItem
 }
@@ -99,23 +100,23 @@ fun ContextMenu.item(name: ObservableValue<String>, keyCombination: KeyCombinati
 /**
  * Add a separator to the contextmenu
  */
-fun ContextMenu.separator(op: (SeparatorMenuItem.() -> Unit)? = null) {
+fun ContextMenu.separator(op: SeparatorMenuItem.() -> Unit = {}) {
     val separator = SeparatorMenuItem()
-    op?.invoke(separator)
+    op(separator)
     this += separator
 }
 
 //Menu extensions
-fun Menu.menu(name: String? = null, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (Menu.() -> Unit)? = null): Menu {
+fun Menu.menu(name: String? = null, keyCombination: KeyCombination? = null, graphic: Node? = null, op: Menu.() -> Unit = {}): Menu {
     val menu = Menu(name, graphic)
     keyCombination?.apply { menu.accelerator = this }
-    op?.invoke(menu)
+    op(menu)
     this += menu
     return menu
 }
 
 //Menu extensions
-fun Menu.menu(name: String? = null, keyCombination: String, graphic: Node? = null, op: (Menu.() -> Unit)? = null) =
+fun Menu.menu(name: String? = null, keyCombination: String, graphic: Node? = null, op: Menu.() -> Unit = {}) =
     menu(name, KeyCombination.valueOf(keyCombination), graphic, op)
 
 /**
@@ -123,42 +124,80 @@ fun Menu.menu(name: String? = null, keyCombination: String, graphic: Node? = nul
  * op block operates on the MenuItem. This deprecation was made to align the menuitem builder with the other builders.
  */
 @Deprecated("Use the item builder instead, which expects an action parameter", ReplaceWith("item(name, KeyCombination.valueOf(keyCombination), graphic).action(onAction)"))
-fun Menu.menuitem(name: String, keyCombination: String, graphic: Node? = null, onAction: (() -> Unit)? = null) =
-    item(name, KeyCombination.valueOf(keyCombination), graphic).apply { if (onAction != null) action(onAction) }
+fun Menu.menuitem(name: String, keyCombination: String, graphic: Node? = null, onAction: () -> Unit = {}) =
+    item(name, KeyCombination.valueOf(keyCombination), graphic).apply { action(onAction) }
 
 /**
  * Create a MenuItem. The op block will be configured as the `setOnAction`. This will be deprecated in favor of the `item` call, where the
  * op block operates on the MenuItem. This deprecation was made to align the menuitem builder with the other builders.
  */
 @Deprecated("Use the item builder instead, which expects an action parameter", ReplaceWith("item(name, keyCombination, graphic).action(onAction)"))
-fun Menu.menuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, onAction: ((ActionEvent) -> Unit)? = null): MenuItem {
+fun Menu.menuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, onAction: (ActionEvent) -> Unit = {}): MenuItem {
     val menuItem = MenuItem(name, graphic);
     keyCombination?.apply { menuItem.accelerator = this }
     graphic?.apply { menuItem.graphic = graphic }
-    onAction?.apply { menuItem.setOnAction { this.invoke(it) } }
+    menuItem.setOnAction(onAction)
     this += menuItem
     return menuItem
 }
 
 /**
- * Create a MenuItem. The op block operates on the MenuItem where you can call `setOnAction` to provide the menu item action.
+ * Create a MenuItem. The op block operates on the MenuItem where you can call `action` to provide the menu item action.
  * Notice that this differs from the deprecated `menuitem` builder where the op
  * is configured as the `setOnAction` directly.
  */
-fun Menu.item(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (MenuItem.() -> Unit)? = null): MenuItem {
+fun Menu.item(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: MenuItem.() -> Unit = {}): MenuItem {
     val menuItem = MenuItem(name, graphic)
     keyCombination?.apply { menuItem.accelerator = this }
     graphic?.apply { menuItem.graphic = graphic }
-    op?.invoke(menuItem)
+    op(menuItem)
     this += menuItem
     return menuItem
 }
 
-fun MenuButton.item(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (MenuItem.() -> Unit)? = null): MenuItem {
+/**
+ * Create a CustomMenuItem. You must provide a builder inside the `CustomMenuItem` or assign to the `content` property
+ * of the item. The item action is configured with the `action` builder.
+ */
+fun Menu.customitem(keyCombination: KeyCombination? = null, hideOnClick: Boolean = true, op: CustomMenuItem.() -> Unit = {}): CustomMenuItem {
+    val menuItem = CustomMenuItem()
+    menuItem.isHideOnClick = hideOnClick
+    keyCombination?.also { menuItem.accelerator = it }
+    op(menuItem)
+    this += menuItem
+    return menuItem
+}
+
+/**
+ * Create a CustomMenuItem. You must provide a builder inside the `CustomMenuItem` or assign to the `content` property
+ * of the item. The item action is configured with the `action` builder.
+ */
+fun MenuButton.customitem(keyCombination: KeyCombination? = null, hideOnClick: Boolean = true, op: CustomMenuItem.() -> Unit = {}): CustomMenuItem {
+    val menuItem = CustomMenuItem()
+    menuItem.isHideOnClick = hideOnClick
+    keyCombination?.also { menuItem.accelerator = it }
+    op(menuItem)
+    items.add(menuItem)
+    return menuItem
+}
+
+/**
+ * Create a CustomMenuItem. You must provide a builder inside the `CustomMenuItem` or assign to the `content` property
+ * of the item. The item action is configured with the `action` builder.
+ */
+fun ContextMenu.customitem(keyCombination: KeyCombination? = null, hideOnClick: Boolean = true, op: CustomMenuItem.() -> Unit = {}): CustomMenuItem {
+    val menuItem = CustomMenuItem()
+    menuItem.isHideOnClick = hideOnClick
+    keyCombination?.also { menuItem.accelerator = it }
+    op(menuItem)
+    this += menuItem
+    return menuItem
+}
+fun MenuButton.item(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: MenuItem.() -> Unit = {}): MenuItem {
     val menuItem = MenuItem(name, graphic)
     keyCombination?.apply { menuItem.accelerator = this }
     graphic?.apply { menuItem.graphic = graphic }
-    op?.invoke(menuItem)
+    op(menuItem)
     items.add(menuItem)
     return menuItem
 }
@@ -166,7 +205,7 @@ fun MenuButton.item(name: String, keyCombination: KeyCombination? = null, graphi
 /**
  * Create a MenuItem. The op block operates on the MenuItem where you can call `setOnAction` to provide the menu item action.
  */
-fun Menu.item(name: String, keyCombination: String, graphic: Node? = null, op: (MenuItem.() -> Unit)? = null) =
+fun Menu.item(name: String, keyCombination: String, graphic: Node? = null, op: MenuItem.() -> Unit = {}) =
     item(name, KeyCombination.valueOf(keyCombination), graphic, op)
 
 /**
@@ -174,12 +213,12 @@ fun Menu.item(name: String, keyCombination: String, graphic: Node? = null, op: (
  * call `setOnAction` to provide the menu item action. Notice that this differs from the deprecated `menuitem` builder where the op
  * is configured as the `setOnAction` directly.
  */
-fun Menu.item(name: ObservableValue<String>, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (MenuItem.() -> Unit)? = null): MenuItem {
+fun Menu.item(name: ObservableValue<String>, keyCombination: KeyCombination? = null, graphic: Node? = null, op: MenuItem.() -> Unit = {}): MenuItem {
     val menuItem = MenuItem(null, graphic)
     menuItem.textProperty().bind(name)
     keyCombination?.apply { menuItem.accelerator = this }
     graphic?.apply { menuItem.graphic = graphic }
-    op?.invoke(menuItem)
+    op(menuItem)
     this += menuItem
     return menuItem
 }
@@ -227,47 +266,51 @@ fun Menu.separator() {
     this += SeparatorMenuItem()
 }
 
-fun Menu.radiomenuitem(name: String, toggleGroup: ToggleGroup? = null, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (RadioMenuItem.() -> Unit)? = null): RadioMenuItem {
+fun Menu.radiomenuitem(name: String, toggleGroup: ToggleGroup? = null, keyCombination: KeyCombination? = null, graphic: Node? = null, op: RadioMenuItem.() -> Unit = {}): RadioMenuItem {
     val radioMenuItem = RadioMenuItem(name, graphic)
     toggleGroup?.apply { radioMenuItem.toggleGroup = this }
     keyCombination?.apply { radioMenuItem.accelerator = this }
     graphic?.apply { radioMenuItem.graphic = graphic }
-    op?.let { it.invoke(radioMenuItem) }
+    op(radioMenuItem)
     this += radioMenuItem
     return radioMenuItem
 }
 
-fun Menu.checkmenuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (CheckMenuItem.() -> Unit)? = null): CheckMenuItem {
+fun Menu.checkmenuitem(name: String, keyCombination: String, graphic: Node? = null, selected: Property<Boolean>? = null, op: CheckMenuItem.() -> Unit = {}) =
+        checkmenuitem(name, KeyCombination.valueOf(keyCombination), graphic, selected, op)
+
+fun Menu.checkmenuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, selected: Property<Boolean>? = null, op: CheckMenuItem.() -> Unit = {}): CheckMenuItem {
     val checkMenuItem = CheckMenuItem(name, graphic)
     keyCombination?.apply { checkMenuItem.accelerator = this }
     graphic?.apply { checkMenuItem.graphic = graphic }
-    op?.let { it.invoke(checkMenuItem) }
+    selected?.apply { checkMenuItem.selectedProperty().bindBidirectional(this) }
+    op(checkMenuItem)
     this += checkMenuItem
     return checkMenuItem
 }
 
-fun MenuButton.radiomenuitem(name: String, toggleGroup: ToggleGroup? = null, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (RadioMenuItem.() -> Unit)? = null): RadioMenuItem {
+fun MenuButton.radiomenuitem(name: String, toggleGroup: ToggleGroup? = null, keyCombination: KeyCombination? = null, graphic: Node? = null, op: RadioMenuItem.() -> Unit = {}): RadioMenuItem {
     val radioMenuItem = RadioMenuItem(name, graphic)
     toggleGroup?.apply { radioMenuItem.toggleGroup = this }
     keyCombination?.apply { radioMenuItem.accelerator = this }
     graphic?.apply { radioMenuItem.graphic = graphic }
-    op?.invoke(radioMenuItem)
+    op(radioMenuItem)
     items.add(radioMenuItem)
     return radioMenuItem
 }
 
-fun MenuButton.checkmenuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: (CheckMenuItem.() -> Unit)? = null): CheckMenuItem {
+fun MenuButton.checkmenuitem(name: String, keyCombination: KeyCombination? = null, graphic: Node? = null, op: CheckMenuItem.() -> Unit = {}): CheckMenuItem {
     val checkMenuItem = CheckMenuItem(name, graphic)
     keyCombination?.apply { checkMenuItem.accelerator = this }
     graphic?.apply { checkMenuItem.graphic = graphic }
-    op?.invoke(checkMenuItem)
+    op(checkMenuItem)
     items.add(checkMenuItem)
     return checkMenuItem
 }
 
-fun EventTarget.contextmenu(op: (ContextMenu.() -> Unit)? = null) = apply {
-    val menu = if (this is Control && contextMenu != null) contextMenu else ContextMenu()
-    op?.invoke(menu)
+fun EventTarget.contextmenu(op: ContextMenu.() -> Unit = {}) = apply {
+    val menu = (this as? Control)?.contextMenu ?: ContextMenu()
+    op(menu)
     if (this is Control) {
         contextMenu = menu
     } else if (this is Node) {
@@ -281,7 +324,7 @@ fun EventTarget.contextmenu(op: (ContextMenu.() -> Unit)? = null) = apply {
 /**
  * Add a context menu to the target which will be created on demand.
  */
-fun EventTarget.lazyContextmenu(op: (ContextMenu.() -> Unit)? = null) = apply {
+fun EventTarget.lazyContextmenu(op: ContextMenu.() -> Unit = {}) = apply {
     var currentMenu: ContextMenu? = null
     if (this is Node) {
         setOnContextMenuRequested { event ->
@@ -289,7 +332,7 @@ fun EventTarget.lazyContextmenu(op: (ContextMenu.() -> Unit)? = null) = apply {
 
             currentMenu = ContextMenu()
             currentMenu!!.setOnCloseRequest { currentMenu = null }
-            op?.invoke(currentMenu!!)
+            op(currentMenu!!)
             currentMenu!!.show(this, event.screenX, event.screenY)
             event.consume()
         }

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -223,45 +223,6 @@ fun Menu.item(name: ObservableValue<String>, keyCombination: KeyCombination? = n
     return menuItem
 }
 
-/**
- * Create a CustomMenuItem. You must provide a builder inside the `CustomMenuItem` or assign to the `content` property
- * of the item. The item action is configured with the `action` builder.
- */
-fun Menu.customitem(keyCombination: KeyCombination? = null, hideOnClick: Boolean = true, op: (CustomMenuItem.() -> Unit)? = null): CustomMenuItem {
-    val menuItem = CustomMenuItem()
-    menuItem.isHideOnClick = hideOnClick
-    keyCombination?.also { menuItem.accelerator = it }
-    op?.invoke(menuItem)
-    this += menuItem
-    return menuItem
-}
-
-/**
- * Create a CustomMenuItem. You must provide a builder inside the `CustomMenuItem` or assign to the `content` property
- * of the item. The item action is configured with the `action` builder.
- */
-fun MenuButton.customitem(keyCombination: KeyCombination? = null, hideOnClick: Boolean = true, op: (CustomMenuItem.() -> Unit)? = null): CustomMenuItem {
-    val menuItem = CustomMenuItem()
-    menuItem.isHideOnClick = hideOnClick
-    keyCombination?.also { menuItem.accelerator = it }
-    op?.invoke(menuItem)
-    items.add(menuItem)
-    return menuItem
-}
-
-/**
- * Create a CustomMenuItem. You must provide a builder inside the `CustomMenuItem` or assign to the `content` property
- * of the item. The item action is configured with the `action` builder.
- */
-fun ContextMenu.customitem(keyCombination: KeyCombination? = null, hideOnClick: Boolean = true, op: (CustomMenuItem.() -> Unit)? = null): CustomMenuItem {
-    val menuItem = CustomMenuItem()
-    menuItem.isHideOnClick = hideOnClick
-    keyCombination?.also { menuItem.accelerator = it }
-    op?.invoke(menuItem)
-    this += menuItem
-    return menuItem
-}
-
 fun Menu.separator() {
     this += SeparatorMenuItem()
 }

--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -2,7 +2,6 @@
 
 package tornadofx
 
-import com.sun.javafx.scene.control.skin.TableColumnHeader
 import javafx.animation.Animation
 import javafx.animation.PauseTransition
 import javafx.application.Platform
@@ -22,6 +21,7 @@ import javafx.scene.Parent
 import javafx.scene.Scene
 import javafx.scene.control.*
 import javafx.scene.control.cell.TextFieldTableCell
+import javafx.scene.control.skin.TableColumnHeader
 import javafx.scene.input.InputEvent
 import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyEvent

--- a/src/main/java/tornadofx/Rest.kt
+++ b/src/main/java/tornadofx/Rest.kt
@@ -61,23 +61,23 @@ open class Rest : Controller() {
 
     fun reset() = engine.reset()
 
-    fun get(path: String, data: JsonValue? = null, processor: ((Request) -> Unit)? = null) = execute(GET, path, data, processor)
-    fun get(path: String, data: JsonModel, processor: ((Request) -> Unit)? = null) = get(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
+    fun get(path: String, data: JsonValue? = null, processor: (Request) -> Unit = {}) = execute(GET, path, data, processor)
+    fun get(path: String, data: JsonModel, processor: (Request) -> Unit = {}) = get(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
 
-    fun put(path: String, data: JsonValue? = null, processor: ((Request) -> Unit)? = null) = execute(PUT, path, data, processor)
-    fun put(path: String, data: JsonModel, processor: ((Request) -> Unit)? = null) = put(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
-    fun put(path: String, data: InputStream, processor: ((Request) -> Unit)? = null) = execute(PUT, path, data, processor)
+    fun put(path: String, data: JsonValue? = null, processor: (Request) -> Unit = {}) = execute(PUT, path, data, processor)
+    fun put(path: String, data: JsonModel, processor: (Request) -> Unit = {}) = put(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
+    fun put(path: String, data: InputStream, processor: (Request) -> Unit = {}) = execute(PUT, path, data, processor)
 
-    fun patch(path: String, data: JsonValue? = null, processor: ((Request) -> Unit)? = null) = execute(PATCH, path, data, processor)
-    fun patch(path: String, data: JsonModel, processor: ((Request) -> Unit)? = null) = patch(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
-    fun patch(path: String, data: InputStream, processor: ((Request) -> Unit)? = null) = execute(PATCH, path, data, processor)
+    fun patch(path: String, data: JsonValue? = null, processor: (Request) -> Unit = {}) = execute(PATCH, path, data, processor)
+    fun patch(path: String, data: JsonModel, processor: (Request) -> Unit = {}) = patch(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
+    fun patch(path: String, data: InputStream, processor: (Request) -> Unit = {}) = execute(PATCH, path, data, processor)
 
-    fun post(path: String, data: JsonValue? = null, processor: ((Request) -> Unit)? = null) = execute(POST, path, data, processor)
-    fun post(path: String, data: JsonModel, processor: ((Request) -> Unit)? = null) = post(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
-    fun post(path: String, data: InputStream, processor: ((Request) -> Unit)? = null) = execute(POST, path, data, processor)
+    fun post(path: String, data: JsonValue? = null, processor: (Request) -> Unit = {}) = execute(POST, path, data, processor)
+    fun post(path: String, data: JsonModel, processor: (Request) -> Unit = {}) = post(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
+    fun post(path: String, data: InputStream, processor: (Request) -> Unit = {}) = execute(POST, path, data, processor)
 
-    fun delete(path: String, data: JsonValue? = null, processor: ((Request) -> Unit)? = null) = execute(DELETE, path, data, processor)
-    fun delete(path: String, data: JsonModel, processor: ((Request) -> Unit)? = null) = delete(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
+    fun delete(path: String, data: JsonValue? = null, processor: (Request) -> Unit = {}) = execute(DELETE, path, data, processor)
+    fun delete(path: String, data: JsonModel, processor: (Request) -> Unit = {}) = delete(path, JsonBuilder().apply { data.toJSON(this) }.build(), processor)
 
     fun getURI(path: String): URI {
         try {
@@ -103,13 +103,12 @@ open class Rest : Controller() {
 
     }
 
-    fun execute(method: Request.Method, target: String, data: Any? = null, processor: ((Request) -> Unit)? = null): Response {
+    fun execute(method: Request.Method, target: String, data: Any? = null, processor: (Request) -> Unit = {}): Response {
         var request: Rest.Request? = null
         try {
             request = engine.request(atomicseq.addAndGet(1), method, getURI(target), data)
 
-            if (processor != null)
-                processor(request)
+            processor(request)
 
             Platform.runLater { ongoingRequests.add(request) }
             return request.execute()

--- a/src/main/java/tornadofx/Shapes.kt
+++ b/src/main/java/tornadofx/Shapes.kt
@@ -3,22 +3,22 @@ package tornadofx
 import javafx.scene.Parent
 import javafx.scene.shape.*
 
-fun Parent.arc(centerX: Number = 0.0, centerY: Number = 0.0, radiusX: Number = 0.0, radiusY: Number = 0.0, startAngle: Number = 0.0, length: Number = 0.0, op: (Arc.() -> Unit)? = null) =
+fun Parent.arc(centerX: Number = 0.0, centerY: Number = 0.0, radiusX: Number = 0.0, radiusY: Number = 0.0, startAngle: Number = 0.0, length: Number = 0.0, op: Arc.() -> Unit = {}) =
         opcr(this, Arc(centerX.toDouble(), centerY.toDouble(), radiusX.toDouble(), radiusY.toDouble(), startAngle.toDouble(), length.toDouble()), op)
 
-fun Parent.circle(centerX: Number = 0.0, centerY: Number = 0.0, radius: Number = 0.0, op: (Circle.() -> Unit)? = null) =
+fun Parent.circle(centerX: Number = 0.0, centerY: Number = 0.0, radius: Number = 0.0, op: Circle.() -> Unit = {}) =
         opcr(this, Circle(centerX.toDouble(), centerY.toDouble(), radius.toDouble()), op)
 
-fun Parent.cubiccurve(startX: Number = 0.0, startY: Number = 0.0, controlX1: Number = 0.0, controlY1: Number = 0.0, controlX2: Number = 0.0, controlY2: Number = 0.0, endX: Number = 0.0, endY: Number = 0.0, op: (CubicCurve.() -> Unit)? = null) =
+fun Parent.cubiccurve(startX: Number = 0.0, startY: Number = 0.0, controlX1: Number = 0.0, controlY1: Number = 0.0, controlX2: Number = 0.0, controlY2: Number = 0.0, endX: Number = 0.0, endY: Number = 0.0, op: CubicCurve.() -> Unit = {}) =
         opcr(this, CubicCurve(startX.toDouble(), startY.toDouble(), controlX1.toDouble(), controlY1.toDouble(), controlX2.toDouble(), controlY2.toDouble(), endX.toDouble(), endY.toDouble()), op)
 
-fun Parent.ellipse(centerX: Number = 0.0, centerY: Number = 0.0, radiusX: Number = 0.0, radiusY: Number = 0.0, op: (Ellipse.() -> Unit)? = null) =
+fun Parent.ellipse(centerX: Number = 0.0, centerY: Number = 0.0, radiusX: Number = 0.0, radiusY: Number = 0.0, op: Ellipse.() -> Unit = {}) =
         opcr(this, Ellipse(centerX.toDouble(), centerY.toDouble(), radiusX.toDouble(), radiusY.toDouble()), op)
 
-fun Parent.line(startX: Number = 0.0, startY: Number = 0.0, endX: Number = 0.0, endY: Number = 0.0, op: (Line.() -> Unit)? = null) =
+fun Parent.line(startX: Number = 0.0, startY: Number = 0.0, endX: Number = 0.0, endY: Number = 0.0, op: Line.() -> Unit = {}) =
         opcr(this, Line(startX.toDouble(), startY.toDouble(), endX.toDouble(), endY.toDouble()), op)
 
-fun Parent.path(vararg elements: PathElement, op: (Path.() -> Unit)? = null) =
+fun Parent.path(vararg elements: PathElement, op: Path.() -> Unit = {}) =
         opcr(this, Path(*elements), op)
 
 fun Path.moveTo(x: Number = 0.0, y: Number = 0.0) = apply {
@@ -29,8 +29,8 @@ fun Path.hlineTo(x: Number) = apply { elements.add(HLineTo(x.toDouble())) }
 
 fun Path.vlineTo(y: Number) = apply { elements.add(VLineTo(y.toDouble())) }
 
-fun Path.quadqurveTo(controlX: Number = 0.0, controlY: Number = 0.0, x: Number = 0.0, y: Number = 0.0, op: (QuadCurveTo.() -> Unit)? = null) = apply {
-    elements.add(QuadCurveTo(controlX.toDouble(), controlY.toDouble(), x.toDouble(), y.toDouble()).apply { op?.invoke(this) })
+fun Path.quadqurveTo(controlX: Number = 0.0, controlY: Number = 0.0, x: Number = 0.0, y: Number = 0.0, op: QuadCurveTo.() -> Unit = {}) = apply {
+    elements.add(QuadCurveTo(controlX.toDouble(), controlY.toDouble(), x.toDouble(), y.toDouble()).also(op))
 }
 
 fun Path.lineTo(x: Number = 0.0, y: Number = 0.0) = apply {
@@ -41,25 +41,25 @@ fun Path.arcTo(
         radiusX: Number = 0.0, radiusY: Number = 0.0,
         xAxisRotation: Number = 0.0, x: Number = 0.0,
         y: Number = 0.0, largeArcFlag: Boolean = false,
-        sweepFlag: Boolean = false, op: (ArcTo.() -> Unit)? = null) = apply{
-    elements.add(ArcTo(radiusX.toDouble(), radiusY.toDouble(), xAxisRotation.toDouble(), x.toDouble(), y.toDouble(), largeArcFlag, sweepFlag).apply { op?.invoke(this) })
+        sweepFlag: Boolean = false, op: ArcTo.() -> Unit = {}) = apply{
+    elements.add(ArcTo(radiusX.toDouble(), radiusY.toDouble(), xAxisRotation.toDouble(), x.toDouble(), y.toDouble(), largeArcFlag, sweepFlag).also(op))
 }
 
 fun Path.closepath() = apply { elements.add(ClosePath()) }
 
-fun Parent.polygon(vararg points: Number, op: (Polygon.() -> Unit)? = null) =
+fun Parent.polygon(vararg points: Number, op: Polygon.() -> Unit = {}) =
         opcr(this, Polygon(*points.map(Number::toDouble).toTypedArray().toDoubleArray()), op)
 
-fun Parent.polyline(vararg points: Number, op: (Polyline.() -> Unit)? = null) =
+fun Parent.polyline(vararg points: Number, op: Polyline.() -> Unit = {}) =
         opcr(this, Polyline(*points.map(Number::toDouble).toTypedArray().toDoubleArray()), op)
 
-fun Parent.quadcurve(startX: Number = 0.0, startY: Number = 0.0, controlX: Number = 0.0, controlY: Number = 0.0, endX: Number = 0.0, endY: Number = 0.0, op: (QuadCurve.() -> Unit)? = null) =
+fun Parent.quadcurve(startX: Number = 0.0, startY: Number = 0.0, controlX: Number = 0.0, controlY: Number = 0.0, endX: Number = 0.0, endY: Number = 0.0, op: QuadCurve.() -> Unit = {}) =
         opcr(this, QuadCurve(startX.toDouble(), startY.toDouble(), controlX.toDouble(), controlY.toDouble(), endX.toDouble(), endY.toDouble()), op)
 
-fun Parent.rectangle(x: Number = 0.0, y: Number = 0.0, width: Number = 0.0, height: Number = 0.0, op: (Rectangle.() -> Unit)? = null) =
+fun Parent.rectangle(x: Number = 0.0, y: Number = 0.0, width: Number = 0.0, height: Number = 0.0, op: Rectangle.() -> Unit = {}) =
         opcr(this, Rectangle(x.toDouble(), y.toDouble(), width.toDouble(), height.toDouble()), op)
 
-fun Parent.svgpath(content: String? = null, fillRule: FillRule? = null, op: (SVGPath.() -> Unit)? = null): SVGPath {
+fun Parent.svgpath(content: String? = null, fillRule: FillRule? = null, op: SVGPath.() -> Unit = {}): SVGPath {
     val p = SVGPath()
     if (content != null) p.content = content
     if (fillRule != null) p.fillRule = fillRule

--- a/src/main/java/tornadofx/ShutdownExecutor.kt
+++ b/src/main/java/tornadofx/ShutdownExecutor.kt
@@ -1,0 +1,33 @@
+package tornadofx
+
+/**
+ *
+ * @author Anindya Chatterjee
+ */
+internal object ShutdownExecutor {
+    // a task executor to run some routines before
+    // graceful shutdown of JVM
+
+    private var taskList = ArrayList<() -> Unit>()
+
+    init {
+        Runtime.getRuntime().addShutdownHook(Thread {
+            // create the shutdown hook
+            runBeforeShutdown()
+        })
+    }
+
+    fun registerTask(task: () -> Unit) {
+        // add the task to a list
+        taskList.add(task)
+    }
+
+    private fun runBeforeShutdown() {
+        // run the task from list before shutdown
+        taskList.forEach { it.invoke() }
+    }
+}
+
+fun beforeShutdown(task: () -> Unit) {
+    ShutdownExecutor.registerTask(task)
+}

--- a/src/main/java/tornadofx/SmartResize.kt
+++ b/src/main/java/tornadofx/SmartResize.kt
@@ -354,7 +354,9 @@ fun <S> TornadoFXColumn<S>.contentWidth(padding: Double = 0.0, useAsMin: Boolean
 }
 
 fun <S, T : Any> TornadoFXTable<S, T>.resizeColumnsToFitContent(resizeColumns: List<TornadoFXColumn<*>> = contentColumns, maxRows: Int = 50, afterResize: () -> Unit = {}) {
-    val doResize = {
+    //fixme Java 9: resizeColumnToFitContent is not available in JDK9. TableSkinUtils contains it but it not made available to
+    //other modules
+    /*val doResize = {
         val columnType = if (skin is TreeTableViewSkin<*>) TreeTableColumn::class.java else TableColumn::class.java
         val resizer = skin!!.javaClass.getDeclaredMethod("resizeColumnToFitContent", columnType, Int::class.java)
         resizer.isAccessible = true
@@ -370,7 +372,7 @@ fun <S, T : Any> TornadoFXTable<S, T>.resizeColumnsToFitContent(resizeColumns: L
         }
     } else {
         doResize()
-    }
+    }*/
 }
 
 fun <TABLE : Any> resizeCall(

--- a/src/main/java/tornadofx/StackPane.kt
+++ b/src/main/java/tornadofx/StackPane.kt
@@ -1,0 +1,108 @@
+package tornadofx
+
+import javafx.beans.binding.BooleanExpression
+import javafx.beans.property.ReadOnlyObjectProperty
+import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.property.SimpleObjectProperty
+import javafx.beans.value.ChangeListener
+import javafx.scene.Node
+import javafx.scene.layout.StackPane
+
+/**
+ * This property always contains the topmost Node in the children
+ * list of the StackPane
+ */
+val StackPane.contentProperty: ReadOnlyObjectProperty<Node>
+    get() {
+        @Suppress("UNCHECKED_CAST")
+        return properties.getOrPut("tornadofx.contentProperty") {
+            val p = SimpleObjectProperty(children.lastOrNull())
+            children.onChange {
+                p.value = children.lastOrNull()
+            }
+            p
+        } as ReadOnlyObjectProperty<Node>
+    }
+
+val StackPane.content: Node? get() = contentProperty.value
+
+val StackPane.savable: BooleanExpression
+    get() {
+        val savable = SimpleBooleanProperty(true)
+
+        fun updateState() {
+            savable.cleanBind(contentUiComponent<UIComponent>()?.savable
+                    ?: SimpleBooleanProperty(Workspace.defaultSavable))
+        }
+
+        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
+
+        updateState()
+
+        contentProperty.addListener(contentChangeListener)
+
+        return savable
+    }
+
+val StackPane.creatable: BooleanExpression
+    get() {
+        val creatable = SimpleBooleanProperty(true)
+
+        fun updateState() {
+            creatable.cleanBind(contentUiComponent<UIComponent>()?.creatable
+                    ?: SimpleBooleanProperty(Workspace.defaultCreatable))
+        }
+
+        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
+
+        updateState()
+
+        contentProperty.addListener(contentChangeListener)
+
+        return savable
+    }
+
+val StackPane.deletable: BooleanExpression
+    get() {
+        val deletable = SimpleBooleanProperty(true)
+
+        fun updateState() {
+            deletable.cleanBind(contentUiComponent<UIComponent>()?.deletable
+                    ?: SimpleBooleanProperty(Workspace.defaultDeletable))
+        }
+
+        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
+
+        updateState()
+
+        contentProperty.addListener(contentChangeListener)
+
+        return deletable
+    }
+
+
+val StackPane.refreshable: BooleanExpression
+    get() {
+        val refreshable = SimpleBooleanProperty(true)
+
+        fun updateState() {
+            refreshable.cleanBind(contentUiComponent<UIComponent>()?.refreshable
+                    ?: SimpleBooleanProperty(Workspace.defaultRefreshable))
+        }
+
+        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
+
+        updateState()
+
+        contentProperty.addListener(contentChangeListener)
+
+        return refreshable
+    }
+
+inline fun <reified T : UIComponent> StackPane.contentUiComponent(): T? = content?.uiComponent()
+fun StackPane.onDelete() = contentUiComponent<UIComponent>()?.onDelete()
+fun StackPane.onSave() = contentUiComponent<UIComponent>()?.onSave()
+fun StackPane.onCreate() = contentUiComponent<UIComponent>()?.onCreate()
+fun StackPane.onRefresh() = contentUiComponent<UIComponent>()?.onRefresh()
+fun StackPane.onNavigateBack() = contentUiComponent<UIComponent>()?.onNavigateBack() ?: true
+fun StackPane.onNavigateForward() = contentUiComponent<UIComponent>()?.onNavigateForward() ?: true

--- a/src/main/java/tornadofx/TabPane.kt
+++ b/src/main/java/tornadofx/TabPane.kt
@@ -1,0 +1,184 @@
+package tornadofx
+
+import javafx.beans.binding.BooleanBinding
+import javafx.beans.binding.BooleanExpression
+import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.value.ChangeListener
+import javafx.beans.value.ObservableValue
+import javafx.event.EventTarget
+import javafx.scene.Node
+import javafx.scene.control.Tab
+import javafx.scene.control.TabPane
+import javafx.scene.layout.Pane
+import javafx.scene.layout.VBox
+import kotlin.reflect.KClass
+
+fun EventTarget.tabpane(op: TabPane.() -> Unit = {}) = opcr(this, TabPane(), op)
+
+fun <T : Node> TabPane.tab(text: String, content: T, op: T.() -> Unit = {}): Tab {
+    val tab = Tab(text, content)
+    tabs.add(tab)
+    op(content)
+    return tab
+}
+
+@Deprecated("Use the tab builder that extracts the closeable state from UIComponent.closeable instead", ReplaceWith("add(uiComponent)"))
+fun TabPane.tab(uiComponent: UIComponent, closable: Boolean = true, op: Tab.() -> Unit = {}): Tab {
+    val tab = Tab()
+    tab.isClosable = closable
+    tab.textProperty().bind(uiComponent.titleProperty)
+    tab.content = uiComponent.root
+    tabs.add(tab)
+    op(tab)
+    return tab
+}
+
+inline fun <reified  T: UIComponent> TabPane.tab(noinline op: Tab.() -> Unit = {}) = tab(T::class, op)
+fun TabPane.tab(uiComponent: KClass<out UIComponent>, op: Tab.() -> Unit = {}) = tab(find(uiComponent), op)
+
+fun TabPane.tab(uiComponent: UIComponent, op: Tab.() -> Unit = {}): Tab {
+    add(uiComponent.root)
+    return tabs.last().also(op)
+}
+
+fun <T : Node> Iterable<T>.contains(cmp: UIComponent) = any { it == cmp.root }
+
+fun TabPane.contains(cmp: UIComponent) = tabs.map { it.content }.contains(cmp)
+
+fun Tab.disableWhen(predicate: ObservableValue<Boolean>) = disableProperty().cleanBind(predicate)
+fun Tab.enableWhen(predicate: ObservableValue<Boolean>) {
+    val binding = if (predicate is BooleanBinding) predicate.not() else predicate.toBinding().not()
+    disableProperty().cleanBind(binding)
+}
+fun Tab.closeableWhen(predicate: ObservableValue<Boolean>) {
+    closableProperty().bind(predicate)
+}
+
+fun Tab.visibleWhen(predicate: ObservableValue<Boolean>) {
+    fun updateState() {
+        if (predicate.value.not()) tabPane.tabs.remove(this)
+        else if (this !in tabPane.tabs) tabPane.tabs.add(this)
+    }
+    updateState()
+    predicate.onChange { updateState() }
+}
+
+fun Tab.close() = removeFromParent()
+
+val TabPane.savable: BooleanExpression
+    get() {
+        val savable = SimpleBooleanProperty(true)
+
+        fun updateState() {
+            savable.cleanBind(contentUiComponent<UIComponent>()?.savable ?: SimpleBooleanProperty(Workspace.defaultSavable))
+        }
+
+        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
+
+        updateState()
+
+        selectionModel.selectedItem?.contentProperty()?.addListener(contentChangeListener)
+        selectionModel.selectedItemProperty().addListener { _, oldTab, newTab ->
+            updateState()
+            oldTab?.contentProperty()?.removeListener(contentChangeListener)
+            newTab?.contentProperty()?.addListener(contentChangeListener)
+        }
+
+        return savable
+    }
+
+val TabPane.creatable: BooleanExpression
+    get() {
+        val creatable = SimpleBooleanProperty(true)
+
+        fun updateState() {
+            creatable.cleanBind(contentUiComponent<UIComponent>()?.creatable ?: SimpleBooleanProperty(Workspace.defaultCreatable))
+        }
+
+        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
+
+        updateState()
+
+        selectionModel.selectedItem?.contentProperty()?.addListener(contentChangeListener)
+        selectionModel.selectedItemProperty().addListener { _, oldTab, newTab ->
+            updateState()
+            oldTab?.contentProperty()?.removeListener(contentChangeListener)
+            newTab?.contentProperty()?.addListener(contentChangeListener)
+        }
+
+        return savable
+    }
+
+val TabPane.deletable: BooleanExpression
+    get() {
+        val deletable = SimpleBooleanProperty(true)
+
+        fun updateState() {
+            deletable.cleanBind(contentUiComponent<UIComponent>()?.deletable ?: SimpleBooleanProperty(Workspace.defaultDeletable))
+        }
+
+        val contentChangeListener = ChangeListener<Node?> { observable, oldValue, newValue -> updateState() }
+
+        updateState()
+
+        selectionModel.selectedItem?.contentProperty()?.addListener(contentChangeListener)
+        selectionModel.selectedItemProperty().addListener { observable, oldTab, newTab ->
+            updateState()
+            oldTab?.contentProperty()?.removeListener(contentChangeListener)
+            newTab?.contentProperty()?.addListener(contentChangeListener)
+        }
+
+        return deletable
+    }
+
+
+val TabPane.refreshable: BooleanExpression
+    get() {
+        val refreshable = SimpleBooleanProperty(true)
+
+        fun updateState() {
+            refreshable.cleanBind(contentUiComponent<UIComponent>()?.refreshable ?: SimpleBooleanProperty(Workspace.defaultRefreshable))
+        }
+
+        val contentChangeListener = ChangeListener<Node?> { _, _, _ -> updateState() }
+
+        updateState()
+
+        selectionModel.selectedItem?.contentProperty()?.addListener(contentChangeListener)
+        selectionModel.selectedItemProperty().addListener { observable, oldTab, newTab ->
+            updateState()
+            oldTab?.contentProperty()?.removeListener(contentChangeListener)
+            newTab?.contentProperty()?.addListener(contentChangeListener)
+        }
+
+        return refreshable
+    }
+
+inline fun <reified T : UIComponent> TabPane.contentUiComponent(): T? = selectionModel.selectedItem?.content?.uiComponent()
+fun TabPane.onDelete() = contentUiComponent<UIComponent>()?.onDelete()
+fun TabPane.onSave() = contentUiComponent<UIComponent>()?.onSave()
+fun TabPane.onCreate() = contentUiComponent<UIComponent>()?.onCreate()
+fun TabPane.onRefresh() = contentUiComponent<UIComponent>()?.onRefresh()
+fun TabPane.onNavigateBack() = contentUiComponent<UIComponent>()?.onNavigateBack() ?: true
+fun TabPane.onNavigateForward() = contentUiComponent<UIComponent>()?.onNavigateForward() ?: true
+
+fun TabPane.tab(text: String? = null, tag: Any? = null, op: Tab.() -> Unit = {}): Tab {
+    val tab = Tab(text ?: tag?.toString())
+    tab.tag = tag
+    tabs.add(tab)
+    return tab.also(op)
+}
+
+fun Tab.whenSelected(op: () -> Unit) {
+    selectedProperty().onChange { if (it) op() }
+}
+
+fun Tab.select() = apply { tabPane.selectionModel.select(this) }
+
+@Deprecated("No need to use the content{} wrapper anymore, just use a builder directly inside the Tab", ReplaceWith("no content{} wrapper"), DeprecationLevel.WARNING)
+fun Tab.content(op: Pane.() -> Unit): Node {
+    val fake = VBox()
+    op(fake)
+    content = if (fake.children.size == 1) fake.children.first() else fake
+    return content
+}

--- a/src/main/java/tornadofx/TableView.kt
+++ b/src/main/java/tornadofx/TableView.kt
@@ -4,8 +4,10 @@ import javafx.beans.property.ObjectProperty
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.Node
+import javafx.scene.control.SelectionMode
 import javafx.scene.control.TableCell
 import javafx.scene.control.TableColumn
+import javafx.scene.control.TableView
 import javafx.util.Callback
 import javafx.util.StringConverter
 import kotlin.reflect.KClass
@@ -138,4 +140,8 @@ fun <S, T> TableColumn<S, T>.cellCache(scope: Scope  = DefaultScope, cachedGraph
 
 fun <T, S> TableColumn<T, S?>.converter(converter: StringConverter<in S>): TableColumn<T, S?> = apply {
     cellFormat(DefaultScope) { text = converter.toString(it) }
+}
+
+fun <T> TableView<T>.multiSelect(enable: Boolean = true) {
+    selectionModel.selectionMode = if (enable) SelectionMode.MULTIPLE else SelectionMode.SINGLE
 }

--- a/src/main/java/tornadofx/TreeView.kt
+++ b/src/main/java/tornadofx/TreeView.kt
@@ -7,9 +7,7 @@ import javafx.beans.property.Property
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.Node
-import javafx.scene.control.TreeCell
-import javafx.scene.control.TreeItem
-import javafx.scene.control.TreeView
+import javafx.scene.control.*
 import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyEvent
 import javafx.util.Callback
@@ -206,3 +204,11 @@ fun <S> TreeView<S>.cellDecorator(decorator: (TreeCell<S>.(S) -> Unit)) {
  */
 val <T> TreeView<T>.selectedValue: T?
     get() = this.selectionModel.selectedItem?.value
+
+fun <T> TreeView<T>.multiSelect(enable: Boolean = true) {
+    selectionModel.selectionMode = if (enable) SelectionMode.MULTIPLE else SelectionMode.SINGLE
+}
+
+fun <T> TreeTableView<T>.multiSelect(enable: Boolean = true) {
+    selectionModel.selectionMode = if (enable) SelectionMode.MULTIPLE else SelectionMode.SINGLE
+}

--- a/src/main/java/tornadofx/Wizard.kt
+++ b/src/main/java/tornadofx/Wizard.kt
@@ -149,13 +149,15 @@ abstract class Wizard @JvmOverloads constructor(title: String? = null, heading: 
                 addClass(WizardStyles.buttons)
                 button(type = ButtonBar.ButtonData.BACK_PREVIOUS) {
                     textProperty().bind(backButtonTextProperty)
-                    enableWhen { canGoBack }
+                    runLater {
+                        enableWhen(canGoBack)
+                    }
                     action { back() }
                 }
                 button(type = ButtonBar.ButtonData.NEXT_FORWARD) {
                     textProperty().bind(nextButtonTextProperty)
-                    Platform.runLater {
-                        enableWhen { canGoNext.and(hasNext) }
+                    runLater {
+                        enableWhen(canGoNext.and(hasNext))
                     }
                     action { next() }
                 }
@@ -165,8 +167,8 @@ abstract class Wizard @JvmOverloads constructor(title: String? = null, heading: 
                 }
                 button(type = ButtonBar.ButtonData.FINISH) {
                     textProperty().bind(finishButtonTextProperty)
-                    Platform.runLater {
-                        enableWhen { canFinish }
+                    runLater {
+                        enableWhen(canFinish)
                     }
                     action {
                         currentPage.onSave()

--- a/src/main/java/tornadofx/Workspace.kt
+++ b/src/main/java/tornadofx/Workspace.kt
@@ -216,6 +216,8 @@ open class Workspace(title: String = "Workspace", navigationMode: NavigationMode
         }
     }
 
+    val header: ToolBar get() = root.header
+
     private fun navigateForward(): Boolean {
         if (!forwardButton.isDisabled) {
             dock(viewStack[viewPos.get() + 1], false)
@@ -341,6 +343,8 @@ open class Workspace(title: String = "Workspace", navigationMode: NavigationMode
     inline fun <reified T : UIComponent> dock(scope: Scope = this@Workspace.scope, params: Map<*, Any?>? = null) = dock(find<T>(scope, params))
 
     fun dock(child: UIComponent, forward: Boolean = true) {
+        if (child == dockedComponent) return
+
         // Remove everything after viewpos if moving forward
         if (forward) while (viewPos.get() < viewStack.size -1) viewStack.removeAt(viewPos.get() + 1)
 
@@ -351,7 +355,7 @@ open class Workspace(title: String = "Workspace", navigationMode: NavigationMode
         setAsCurrentlyDocked(child)
 
         // Ensure max stack size
-        while (viewStack.size >= maxViewStackDepth)
+        while (viewStack.size >= maxViewStackDepth && viewStack.isNotEmpty())
             viewStack.removeAt(0)
     }
 

--- a/src/main/java/tornadofx/adapters/TornadoFXColumns.kt
+++ b/src/main/java/tornadofx/adapters/TornadoFXColumns.kt
@@ -13,7 +13,7 @@ interface TornadoFXColumn<COLUMN> {
     var prefWidth: Double
     var maxWidth: Double
     var minWidth: Double
-    var width: Double
+    val width: Double
     val minWidthProperty: DoubleProperty
     val maxWidthProperty: DoubleProperty
 }
@@ -37,11 +37,24 @@ class TornadoFXTreeTableColumn(override val column: TreeTableColumn<*, *>) : Tor
         set(value) {
             column.maxWidth = value
         }
-    override var width: Double
+    override val width: Double
         get() = column.width
-        set(value) {
-            column.maxWidth = value
-        }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TornadoFXTreeTableColumn
+
+        if (column != other.column) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return column.hashCode()
+    }
+
 }
 
 class TornadoFxNormalTableColumn(override val column: TableColumn<*, *>) : TornadoFXColumn<TableColumn<*, *>> {
@@ -61,11 +74,23 @@ class TornadoFxNormalTableColumn(override val column: TableColumn<*, *>) : Torna
             column.prefWidth = value
         }
     override val properties = column.properties
-    override var width: Double
+    override val width: Double
         get() = column.width
-        set(value) {
-            column.prefWidth = value
-        }
     override val minWidthProperty get() = column.minWidthProperty()
     override val maxWidthProperty get() = column.maxWidthProperty()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TornadoFxNormalTableColumn
+
+        if (column != other.column) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return column.hashCode()
+    }
 }

--- a/src/main/java/tornadofx/osgi/ChildInterceptorProvider.kt
+++ b/src/main/java/tornadofx/osgi/ChildInterceptorProvider.kt
@@ -1,0 +1,19 @@
+package tornadofx.osgi
+
+import org.osgi.framework.BundleContext
+import tornadofx.*
+import java.util.*
+import kotlin.reflect.KClass
+import kotlin.reflect.full.createInstance
+
+interface ChildInterceptorProvider {
+    val interceptor: ChildInterceptor
+}
+
+inline fun <reified T : ChildInterceptor> BundleContext.registerChildInterceptor() = registerChildInterceptor(T::class)
+fun BundleContext.registerChildInterceptor(interceptorKlass: KClass<out ChildInterceptor>) {
+    val provider = object : ChildInterceptorProvider {
+        override val interceptor = interceptorKlass.createInstance()
+    }
+    registerService(ChildInterceptorProvider::class.java, provider, Hashtable<String, String>())
+}

--- a/src/main/java/tornadofx/osgi/impl/Activator.kt
+++ b/src/main/java/tornadofx/osgi/impl/Activator.kt
@@ -8,17 +8,17 @@ import java.util.*
 internal class Activator : BundleActivator {
     lateinit var applicationListener: ApplicationListener
     lateinit var stylesheetListener: StylesheetListener
-    lateinit var viewListener : ViewListener
-
+    lateinit var viewListener: ViewListener
+    lateinit var interceptorListener: InterceptorListener
     override fun start(context: BundleContext) {
         applicationListener = ApplicationListener(context)
         stylesheetListener = StylesheetListener(context)
         viewListener = ViewListener(context)
-
+        interceptorListener = InterceptorListener(context)
         context.addServiceListener(applicationListener)
         context.addServiceListener(stylesheetListener)
         context.addServiceListener(viewListener)
-
+        context.addServiceListener(interceptorListener)
         val cssOptions = Hashtable<String, String>()
         cssOptions["url.handler.protocol"] = "css"
         cssOptions["url.content.mimetype"] = "text/css"

--- a/src/main/java/tornadofx/osgi/impl/InterceptorListener.kt
+++ b/src/main/java/tornadofx/osgi/impl/InterceptorListener.kt
@@ -1,0 +1,34 @@
+package tornadofx.osgi.impl
+
+import org.osgi.framework.BundleContext
+import org.osgi.framework.ServiceEvent
+import org.osgi.framework.ServiceListener
+import org.osgi.util.tracker.ServiceTracker
+import tornadofx.*
+import tornadofx.osgi.ChildInterceptorProvider
+
+class InterceptorListener(val context: BundleContext) : ServiceListener {
+    val tracker = ServiceTracker<ChildInterceptorProvider, Any>(context, context.createFilter("(&(objectClass=${ChildInterceptorProvider::class.java.name}))"), null)
+
+    init {
+        tracker.open()
+        tracker.withEach {
+            FX.addChildInterceptor(it.interceptor)
+        }
+    }
+
+    override fun serviceChanged(event: ServiceEvent) {
+        if (event.isChildInterceptorProviderEvent()) {
+            val provider = context.getService(event.serviceReference) as ChildInterceptorProvider
+
+            if (event.type == ServiceEvent.REGISTERED) {
+                FX.addChildInterceptor(provider.interceptor)
+            } else if (event.type == ServiceEvent.UNREGISTERING) {
+                FX.removeChildInterceptor(provider.interceptor)
+            }
+        }
+    }
+
+    private fun ServiceEvent.isChildInterceptorProviderEvent() = objectClass == ChildInterceptorProvider::class.qualifiedName
+
+}

--- a/src/main/resources/tornadofx/listmenu.css
+++ b/src/main/resources/tornadofx/listmenu.css
@@ -22,6 +22,10 @@
     -fx-color: -fx-hover-base;
 }
 
+.list-menu .list-item:disabled {
+    -fx-opacity: 0.4;
+}
+
 .list-menu.blue {
     -fx-graphic-fixed-size: 2.5em;
     -fx-background-color: #1e88cf;

--- a/src/main/resources/tornadofx/maskpane.css
+++ b/src/main/resources/tornadofx/maskpane.css
@@ -1,0 +1,9 @@
+.mask-pane {
+    -fx-background-color: rgba(0,0,0,0.5);
+    -fx-accent: aliceblue;
+}
+
+.mask-pane > .progress-indicator {
+    -fx-max-width: 300;
+    -fx-max-height: 300;
+}

--- a/src/test/kotlin/tornadofx/testapps/CommandTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/CommandTest.kt
@@ -20,6 +20,14 @@ class CommandTest : View("Command test") {
             menubar {
                 menu("Talk") {
                     item("Say hello").command = ctrl.helloCommand
+                    customitem {
+                        vbox {
+                            text("I'm custom!")
+                        }
+                        action {
+                            println("Custom item clicked!")
+                        }
+                    }
                 }
             }
         }

--- a/src/test/kotlin/tornadofx/testapps/DataGridTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/DataGridTest.kt
@@ -1,10 +1,6 @@
 package tornadofx.testapps
 
-import javafx.collections.FXCollections
-import javafx.scene.Parent
-import javafx.scene.control.SelectionMode
 import tornadofx.*
-import tornadofx.testapps.DataGridTestApp.Companion.images
 
 class DataGridTestApp : App(DataGridTest::class, DataGridStyles::class) {
     companion object {
@@ -31,54 +27,55 @@ class DataGridTestApp : App(DataGridTest::class, DataGridStyles::class) {
 }
 
 class DataGridTest : View("DataGrid") {
-    var datagrid: DataGrid<String> by singleAssign()
-    val list = FXCollections.observableArrayList<String>()
-    var paginator = DataGridPaginator(list, itemsPerPage = 5)
+//    var datagrid: DataGrid<String> by singleAssign()
+//    val list = FXCollections.observableArrayList<String>()
+//    var paginator = DataGridPaginator(list, itemsPerPage = 5)
 
     override val root = borderpane {
-        left {
-            vbox {
-                combobox(values = images.keys.toList()) {
-                    promptText = "Select images"
-                    valueProperty().onChange {
-                        list.setAll(images[it])
-                    }
-                    shortcut("k") { value = "kittens" }
-                    shortcut("p") { value = "puppies" }
-                }
-                button("Add").action {
-                    list.add("http://i.imgur.com/bvqTBT0b.jpg")
-                }
-            }
-        }
-        center {
-            datagrid = datagrid(paginator.items) {
-                setPrefSize(550.0, 550.0)
-
-                selectionModel.selectionMode = SelectionMode.SINGLE
-                cellWidth = 164.0
-                cellHeight = 164.0
-
-                cellCache {
-                    imageview(it, true)
-                }
-
-                onUserSelect(1) {
-                    println("Selected $it")
-                }
-            }
-        }
-        bottom {
-            vbox {
-                add(paginator)
-                hbox {
-                    label(stringBinding(datagrid.selectionModel.selectedItems) { joinToString(", ") })
-                    button("Remove from index 2").action {
-                        if (list.size > 2) list.removeAt(2)
+        /*        left {
+                    vbox {
+                        combobox(values = images.keys.toList()) {
+                            promptText = "Select images"
+                            valueProperty().onChange {
+                                list.setAll(images[it])
+                            }
+                            shortcut("k") { value = "kittens" }
+                            shortcut("p") { value = "puppies" }
+                        }
+                        button("Add").action {
+                            list.add("http://i.imgur.com/bvqTBT0b.jpg")
+                        }
                     }
                 }
-            }
-        }
+                center {
+                    datagrid = datagrid(paginator.items) {
+                        setPrefSize(550.0, 550.0)
+
+                        selectionModel.selectionMode = SelectionMode.SINGLE
+                        cellWidth = 164.0
+                        cellHeight = 164.0
+
+                        cellCache {
+                            imageview(it, true)
+                        }
+
+                        onUserSelect(1) {
+                            println("Selected $it")
+                        }
+                    }
+                }
+                bottom {
+                    vbox {
+                        add(paginator)
+                        hbox {
+                            label(stringBinding(datagrid.selectionModel.selectedItems) { joinToString(", ") })
+                            button("Remove from index 2").action {
+                                if (list.size > 2) list.removeAt(2)
+                            }
+                        }
+                    }
+                }
+                */
     }
 }
 

--- a/src/test/kotlin/tornadofx/testapps/DataGridTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/DataGridTest.kt
@@ -1,6 +1,10 @@
 package tornadofx.testapps
 
+import javafx.collections.FXCollections
+import javafx.scene.Parent
+import javafx.scene.control.SelectionMode
 import tornadofx.*
+import tornadofx.testapps.DataGridTestApp.Companion.images
 
 class DataGridTestApp : App(DataGridTest::class, DataGridStyles::class) {
     companion object {
@@ -27,52 +31,55 @@ class DataGridTestApp : App(DataGridTest::class, DataGridStyles::class) {
 }
 
 class DataGridTest : View("DataGrid") {
-//    var datagrid: DataGrid<String> by singleAssign()
-//    val list = FXCollections.observableArrayList<String>()
-//
-    override val root = borderpane {
-//        left {
-//            vbox {
-//                combobox(values = images.keys.toList()) {
-//                    promptText = "Select images"
-//                    valueProperty().onChange {
-//                        list.setAll(images[it])
-//                    }
-//                    shortcut("k") { value = "kittens" }
-//                    shortcut("p") { value = "puppies" }
-//                }
-//                button("Add").action {
-//                    list.add("http://i.imgur.com/bvqTBT0b.jpg")
-//                }
-//            }
-//        }
-//        center {
-//            datagrid = datagrid(list) {
-//                setPrefSize(550.0, 550.0)
-//
-//                selectionModel.selectionMode = SelectionMode.SINGLE
-//                //maxCellsInRow = 3
-//                //maxRows = 3
-//                cellWidth = 164.0
-//                cellHeight = 164.0
-//
-//                cellCache {
-//                    imageview(it, true)
-//                }
-//
-//                onUserSelect(1) {
-//                    println("Selected $it")
-//                }
-//            }
-//        }
-//        bottom {
-//            label(stringBinding(datagrid.selectionModel.selectedItems) { joinToString(", ") })
-//            button("Remove from index 2").action {
-//                list.removeAt(2)
-//            }
-//        }
-    }
+    var datagrid: DataGrid<String> by singleAssign()
+    val list = FXCollections.observableArrayList<String>()
+    var paginator = DataGridPaginator(list, itemsPerPage = 5)
 
+    override val root = borderpane {
+        left {
+            vbox {
+                combobox(values = images.keys.toList()) {
+                    promptText = "Select images"
+                    valueProperty().onChange {
+                        list.setAll(images[it])
+                    }
+                    shortcut("k") { value = "kittens" }
+                    shortcut("p") { value = "puppies" }
+                }
+                button("Add").action {
+                    list.add("http://i.imgur.com/bvqTBT0b.jpg")
+                }
+            }
+        }
+        center {
+            datagrid = datagrid(paginator.items) {
+                setPrefSize(550.0, 550.0)
+
+                selectionModel.selectionMode = SelectionMode.SINGLE
+                cellWidth = 164.0
+                cellHeight = 164.0
+
+                cellCache {
+                    imageview(it, true)
+                }
+
+                onUserSelect(1) {
+                    println("Selected $it")
+                }
+            }
+        }
+        bottom {
+            vbox {
+                add(paginator)
+                hbox {
+                    label(stringBinding(datagrid.selectionModel.selectedItems) { joinToString(", ") })
+                    button("Remove from index 2").action {
+                        if (list.size > 2) list.removeAt(2)
+                    }
+                }
+            }
+        }
+    }
 }
 
 class DataGridStyles : Stylesheet() {

--- a/src/test/kotlin/tornadofx/testapps/ExpandableTableTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/ExpandableTableTest.kt
@@ -25,10 +25,10 @@ class ExpandableTableTest : View("Smart Resize Demo") {
     override val root = tableview(rooms) {
         prefWidth = 600.0
 
-        column("#", Room::id).contentWidth(10.0, true, true)
-        column("Number", Room::number).weigthedWidth(1.0)
-        column("Bed", Room::bed).apply {
-            weigthedWidth(2.0)
+        readonlyColumn("#", Room::id).contentWidth(10.0, true, true)
+        readonlyColumn("Number", Room::number).weightedWidth(1.0)
+        readonlyColumn("Bed", Room::bed).apply {
+            weightedWidth(2.0)
             cellFormat {
                 graphic = cache {
                     textfield(itemProperty()) {
@@ -39,15 +39,15 @@ class ExpandableTableTest : View("Smart Resize Demo") {
                 }
             }
         }
-        column("Type", Room::type).weigthedWidth(2.0)
+        readonlyColumn("Type", Room::type).weightedWidth(2.0)
 
         smartResize()
 
         rowExpander {
             tableview(it.occupancy) {
-                column("Occupancy", Occupancy::id)
-                column("Date", Occupancy::date)
-                column("Customer", Occupancy::customer)
+                readonlyColumn("Occupancy", Occupancy::id)
+                readonlyColumn("Date", Occupancy::date)
+                readonlyColumn("Customer", Occupancy::customer)
                 prefHeight = 100.0
             }
         }

--- a/src/test/kotlin/tornadofx/testapps/MultipleLifecycleAsyncApp.kt
+++ b/src/test/kotlin/tornadofx/testapps/MultipleLifecycleAsyncApp.kt
@@ -1,0 +1,25 @@
+package tornadofx.testapps
+
+import tornadofx.*
+
+class MultipleLifecycleAsyncApp : App(MultipleLifecycleAsyncView::class)
+
+class MultipleLifecycleAsyncView : View("Multiple Lifecycle Async") {
+    val controller: MultipleLifecycleAsyncController by inject()
+    override val root = pane {
+        button("Robot-click to repeat bug") {
+            id = "bug"
+            action {
+                runAsync {
+                    controller.onAction("button clicked")
+                }
+            }
+        }
+    }
+}
+
+class MultipleLifecycleAsyncController : Controller() {
+    fun onAction(message: String) {
+        println(message)
+    }
+}

--- a/src/test/kotlin/tornadofx/testapps/NestedTableColumns.kt
+++ b/src/test/kotlin/tornadofx/testapps/NestedTableColumns.kt
@@ -14,10 +14,10 @@ class NestedTableColumns : View("Nested Table Columns") {
     )
 
     override val root = tableview(people) {
-        column("Name", Person::name)
+        readonlyColumn("Name", Person::name)
         nestedColumn("Email addresses") {
-            column("Primary Email", Person::primaryEmail)
-            column("Secondary Email", Person::secondaryEmail)
+            readonlyColumn("Primary Email", Person::primaryEmail)
+            readonlyColumn("Secondary Email", Person::secondaryEmail)
         }
     }
 }

--- a/src/test/kotlin/tornadofx/testapps/TableViewSortFilterTest.kt
+++ b/src/test/kotlin/tornadofx/testapps/TableViewSortFilterTest.kt
@@ -30,11 +30,11 @@ class TableViewSortFilterTest : View("Table Sort and Filter") {
 		textfield = textfield()
 
 		table = tableview {
-			column("ID", Person::id)
+			readonlyColumn("ID", Person::id)
 			column("Name", Person::name)
 			nestedColumn("DOB") {
-				column("Birthday", Person::birthday)
-				column("Age", Person::age).contentWidth()
+				readonlyColumn("Birthday", Person::birthday)
+				readonlyColumn("Age", Person::age).contentWidth()
 			}
             columnResizePolicy = SmartResize.POLICY
 		}

--- a/src/test/kotlin/tornadofx/tests/AsyncTest.kt
+++ b/src/test/kotlin/tornadofx/tests/AsyncTest.kt
@@ -1,0 +1,101 @@
+package tornadofx.tests
+
+import javafx.scene.control.Button
+import javafx.scene.layout.BorderPane
+import javafx.scene.layout.Pane
+import javafx.scene.layout.StackPane
+import javafx.stage.Stage
+import org.junit.Assert
+import org.junit.Test
+import org.testfx.api.FxToolkit
+import tornadofx.*
+import java.util.concurrent.CountDownLatch
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class AsyncTest {
+    val primaryStage: Stage = FxToolkit.registerPrimaryStage()
+
+    @Test
+    fun runAsyncWithOverlay() {
+        //Initially container has embedded node
+        val container = BorderPane()
+        val node = Pane()
+        val mask = Pane()
+
+        container.center = node
+        assertEquals(container.center, node)
+
+        //This latch will be used to control asynchronously executed task, it's a part of the test
+        val latch = Latch()
+        assertTrue(latch.locked)
+
+        //This is a standard CountDownLatch and will be used to synchronize test thread with application thread
+        val appThreadLatch = CountDownLatch(1)
+
+        //ui is needed here because only after task is executed we can check if overlay is removed propertly
+        //and it can only be used from within a UIComponent, so we need a temporary object
+        val component = object : Controller() {
+            fun run() = node.runAsyncWithOverlay(latch, null, mask) ui { appThreadLatch.countDown() }
+        }
+        component.run()
+
+        //Until latch is released, a node is replaced with StackPane containing both the original component and the mask
+        assertNotEquals(node, container.center)
+        assertTrue(container.center is StackPane)
+        assertTrue((container.center as StackPane).children.containsAll(setOf(node, mask)))
+
+        //The working thread (test thread in this case) proceeds, which should result in removing overlay
+        latch.release()
+        assertFalse(latch.locked)
+
+        //Waiting until we have confirmed post-task ui execution
+        appThreadLatch.await()
+
+        //At this point overlay should be removed and node should be again in its original place
+        assertEquals(node, container.center)
+    }
+
+    @Test
+    fun latch() {
+        //Latch set for 5 concurrent tasks
+        val count = 5
+        val latch = Latch(count)
+        val button = Button()
+
+        assertFalse(button.disabledProperty().value)
+
+        //Button should stay disabled until all tasks are over
+        button.disableWhen(latch.lockedProperty())
+
+        (1..count).forEach {
+            assertTrue(button.disabledProperty().value)
+            assertTrue(latch.locked)
+            assertTrue(latch.lockedProperty().value)
+            latch.countDown()
+            //Latch count should decrease after each iteration
+            Assert.assertEquals(count, (it + latch.count).toInt())
+        }
+
+        assertFalse(button.disabledProperty().value)
+        assertFalse(latch.locked)
+
+        //Should have no effect anyway
+        latch.release()
+        assertFalse(button.disabledProperty().value)
+        assertFalse(latch.locked)
+    }
+
+    @Test
+    fun runAsync() {
+        tornadofx.runAsync(daemon = true) {
+            assertTrue { Thread.currentThread().isDaemon }
+        }
+        tornadofx.runAsync {
+            assertFalse { Thread.currentThread().isDaemon }
+        }
+    }
+
+}

--- a/src/test/kotlin/tornadofx/tests/ChildInterceptorTest.kt
+++ b/src/test/kotlin/tornadofx/tests/ChildInterceptorTest.kt
@@ -1,0 +1,81 @@
+package tornadofx.tests
+
+import javafx.event.EventTarget
+import javafx.scene.Node
+import javafx.scene.layout.Pane
+import javafx.stage.Stage
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+import org.testfx.api.FxToolkit
+import tornadofx.*
+import kotlin.test.assertEquals
+
+abstract class BaseInterceptor : ChildInterceptor {
+	var intercepted: Boolean = false
+}
+
+class DummyPane : Pane()
+
+fun EventTarget.dummyPane(op: DummyPane.() -> Unit = {}): DummyPane {
+	return opcr(this, DummyPane(), op)
+}
+
+class FirstInterceptor : BaseInterceptor() {
+	override fun invoke(parent: EventTarget, node: Node, index: Int?): Boolean = when (parent) {
+		is DummyPane -> {
+			intercepted = true
+			true
+		}
+		else -> false
+	}
+}
+
+class SecondInterceptor : BaseInterceptor() {
+	override fun invoke(parent: EventTarget, node: Node, index: Int?): Boolean = when (parent) {
+		is DummyPane -> {
+			intercepted = true
+			true
+		}
+		else -> false
+	}
+}
+
+class MyTestView : View("TestView") {
+	override val root = dummyPane {
+		button {}
+	}
+}
+
+class ChildInterceptorTest {
+
+	companion object {
+		val app = App(MyTestView::class)
+
+		@JvmStatic
+		@BeforeClass
+		fun before() {
+			val primaryStage: Stage = FxToolkit.registerPrimaryStage()
+			FX.registerApplication(FxToolkit.setupApplication {
+				app
+			}, primaryStage)
+		}
+
+		@JvmStatic
+		@AfterClass
+		fun after() {
+			FxToolkit.cleanupApplication(app)
+		}
+	}
+
+	@Test
+	fun interceptorsLoaded() {
+		assertEquals(FX.childInterceptors.size, 2)
+	}
+
+
+	@Test
+	fun onlyOneInterceptorShouldWork() {
+		assertEquals(1, FX.childInterceptors.map { it as BaseInterceptor }.filter { it.intercepted }.size)
+	}
+}

--- a/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
+++ b/src/test/kotlin/tornadofx/tests/CollectionsTest.kt
@@ -1,65 +1,172 @@
 package tornadofx.tests
 
+import org.junit.Test
+import tornadofx.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
 class CollectionsTest {
 
-//    @Test
-//    fun testMoveWithValidIndex() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//
-//        list.move(2, 3)
-//
-//        assertEquals(mutableListOf(1, 3, 4, 2), list)
-//    }
-//
-//    @Test
-//    fun testMoveWithInvalidIndex() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//
-//        try {
-//            list.move(2, 102)
-//        } catch (e: Exception) {
-//            assert(e is IllegalStateException)
-//        }
-//    }
-//
-//    @Test
-//    fun testMoveWithInvalidItem() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//
-//        list.move(10, 1)
-//
-//        assertEquals(mutableListOf(1, 2, 3, 4), list)
-//    }
-//
-//    @Test
-//    fun testMoveAtForward() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//        val newIndex = 2
-//
-//        list.moveAt(0, newIndex)
-//
-//        assertEquals(1, list[newIndex])
-//    }
-//
-//    @Test
-//    fun testMoveAtBackward() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//        val newIndex = 0
-//
-//        list.moveAt(2, newIndex)
-//
-//        assertEquals(3, list[newIndex])
-//    }
-//
-//    @Test
-//    fun testMoveAtWithInvalidNewIndex() {
-//        val list = mutableListOf(1, 2, 3, 4)
-//        val newIndex = 10
-//
-//        try {
-//            list.moveAt(2, newIndex)
-//        } catch (e: Exception) {
-//            assert(e is IllegalStateException)
-//        }
-//    }
+    @Test
+    fun testMoveWithValidIndex() {
+        val list = mutableListOf(1, 2, 3, 4)
+
+        list.move(2, 3)
+
+        assertEquals(mutableListOf(1, 3, 4, 2), list)
+    }
+
+    @Test
+    fun testMoveWithInvalidIndex() {
+        val list = mutableListOf(1, 2, 3, 4)
+
+        try {
+            list.move(2, 102)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+
+    @Test
+    fun testMoveWithInvalidItem() {
+        val list = mutableListOf(1, 2, 3, 4)
+
+        list.move(10, 1)
+
+        assertEquals(mutableListOf(1, 2, 3, 4), list)
+    }
+
+    @Test
+    fun testMoveAtForward() {
+        val list = mutableListOf(1, 2, 3, 4)
+        val newIndex = 2
+
+        list.moveAt(0, newIndex)
+
+        assertEquals(1, list[newIndex])
+    }
+
+    @Test
+    fun testMoveAtBackward() {
+        val list = mutableListOf(1, 2, 3, 4)
+        val newIndex = 0
+
+        list.moveAt(2, newIndex)
+
+        assertEquals(3, list[newIndex])
+    }
+
+    @Test
+    fun testMoveAtWithInvalidNewIndex() {
+        val list = mutableListOf(1, 2, 3, 4)
+        val newIndex = 10
+
+        try {
+            list.moveAt(2, newIndex)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+
+
+    @Test
+    fun testMoveAllValidIndex() {
+        val list = mutableListOf(1, 2, 3, 4, 5)
+
+        list.moveAll(2, { it < 3 })
+
+        assertEquals(mutableListOf(3, 4, 1, 2, 5), list)
+    }
+
+    @Test
+    fun testMoveAllInvalidIndex() {
+        val list = mutableListOf(1, 2, 3, 4, 5)
+
+        try {
+            list.moveAll(101, { it < 3 })
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+
+    @Test
+    fun testMoveUpAtValidIndex() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        list.moveUpAt(2)
+
+        assertEquals(listOf(0, 2, 1, 3, 4), list)
+    }
+
+    @Test
+    fun testMoveUpAtInvalidIndex() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        try {
+            list.moveUpAt(10)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+
+    @Test
+    fun testMoveDownAtValidIndex() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        list.moveDownAt(2)
+
+        assertEquals(listOf(0, 1, 3, 2, 4), list)
+    }
+
+    @Test
+    fun testMoveDownAtInvalidIndex() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        try {
+            list.moveDownAt(10)
+        } catch (e: Exception) {
+            assert(e is IllegalStateException)
+        }
+    }
+
+    @Test
+    fun testMoveUpWithValidItem() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        val result = list.moveUp(2)
+
+        assertTrue(result)
+        assertEquals(listOf(0, 2, 1, 3, 4), list)
+    }
+
+    @Test
+    fun testMoveUpWithInvalidItem() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        val result = list.moveUp(10)
+
+        assertFalse(result)
+        assertEquals(listOf(0, 1, 2, 3, 4), list)
+    }
+
+    @Test
+    fun testMoveDownWithValidItem() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        val result = list.moveDown(2)
+
+        assertTrue(result)
+        assertEquals(listOf(0, 1, 3, 2, 4), list)
+    }
+
+    @Test
+    fun testMoveDownWithInvalidItem() {
+        val list = mutableListOf(0, 1, 2, 3, 4)
+
+        val result = list.moveDown(10)
+
+        assertFalse(result)
+        assertEquals(listOf(0, 1, 2, 3, 4), list)
+    }
 }

--- a/src/test/kotlin/tornadofx/tests/ControlsTest.kt
+++ b/src/test/kotlin/tornadofx/tests/ControlsTest.kt
@@ -8,9 +8,9 @@ import javafx.scene.layout.VBox
 import javafx.util.StringConverter
 import javafx.util.converter.NumberStringConverter
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 import org.testfx.api.FxToolkit
-import org.testfx.toolkit.ToolkitService
 import tornadofx.*
 import java.text.NumberFormat
 import java.util.*
@@ -24,6 +24,11 @@ class TestView : View() {
 }
 
 class ControlsTest {
+
+    @Before
+    fun setupFX() {
+        FxToolkit.registerPrimaryStage()
+    }
 
     @Test
     fun testTextfield() {
@@ -61,6 +66,7 @@ class ControlsTest {
 
     @Test
     fun testLabelWithStringObservable() {
+
         val view = TestView()
         val property = SimpleStringProperty("Daan")
         val label = view.label(property)
@@ -75,7 +81,6 @@ class ControlsTest {
 
     @Test
     fun testLabelWithIntegerObservable() {
-        FxToolkit.registerPrimaryStage()
 
         val view = TestView()
         val property = SimpleIntegerProperty(12718)

--- a/src/test/kotlin/tornadofx/tests/InternalWindowClosingTest.kt
+++ b/src/test/kotlin/tornadofx/tests/InternalWindowClosingTest.kt
@@ -1,0 +1,38 @@
+package tornadofx.tests
+
+import javafx.scene.Scene
+import javafx.scene.layout.Pane
+import javafx.stage.Stage
+import org.junit.Test
+import org.testfx.api.FxToolkit
+import tornadofx.*
+import kotlin.test.*
+
+/**
+ * Tests if it's possible to open an [InternalWindow] instance and then close it using [UIComponent.close]
+ */
+class InternalWindowClosingTest {
+    val primaryStage: Stage = FxToolkit.registerPrimaryStage()
+
+    @Test
+    fun testClosing() {
+        val owner = Pane()
+
+        val view = object : View() {
+            override val root = pane()
+            fun executeClose() { close() }
+        }
+
+        FxToolkit.setupFixture {
+            primaryStage.scene = Scene(owner)
+            primaryStage.show()
+            val iw = InternalWindow(null, true, true, true);
+            iw.open(view, owner)
+            assertNotNull(iw.scene)
+            assertTrue(view.isDocked)
+            view.executeClose()
+            assertNull(iw.scene)
+            assertFalse(view.isDocked)
+        }
+    }
+}

--- a/src/test/kotlin/tornadofx/tests/LayoutsTest.kt
+++ b/src/test/kotlin/tornadofx/tests/LayoutsTest.kt
@@ -1,0 +1,58 @@
+package tornadofx.tests
+
+import javafx.scene.Scene
+import javafx.scene.control.ScrollPane
+import javafx.scene.layout.Pane
+import javafx.scene.layout.VBox
+import javafx.stage.Stage
+import org.junit.Test
+import org.testfx.api.FxToolkit
+import tornadofx.*
+import kotlin.test.assertEquals
+
+/**
+ *
+ * @author Anindya Chatterjee
+ */
+class RegionTest {
+    val primaryStage: Stage = FxToolkit.registerPrimaryStage()
+
+    lateinit var vbox: VBox
+
+    @Test
+    fun testFitToParentSize() {
+        FxToolkit.setupFixture {
+            val root = Pane().apply {
+                vbox {
+                    this@RegionTest.vbox = this
+                    fitToParentSize()
+                }
+                setPrefSize(400.0, 160.0)
+            }
+            primaryStage.scene = Scene(root)
+            primaryStage.show()
+
+            assertEquals(root.width, vbox.width)
+            assertEquals(root.height, vbox.height)
+        }
+    }
+
+    @Test
+    fun testFitToSize() {
+        FxToolkit.setupFixture {
+            val root = ScrollPane().apply {
+                content = vbox {
+                    this@RegionTest.vbox = this
+                }
+                setPrefSize(400.0, 160.0)
+            }
+
+            vbox.fitToSize(root)
+            primaryStage.scene = Scene(root)
+            primaryStage.show()
+
+            assertEquals(root.width, vbox.width)
+            assertEquals(root.height, vbox.height)
+        }
+    }
+}

--- a/src/test/kotlin/tornadofx/tests/MultipleLifecycleAsyncAppTest.kt
+++ b/src/test/kotlin/tornadofx/tests/MultipleLifecycleAsyncAppTest.kt
@@ -1,0 +1,77 @@
+package tornadofx.tests
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.Timeout
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.testfx.api.FxRobot
+import org.testfx.api.FxToolkit
+import tornadofx.*
+import tornadofx.testapps.MultipleLifecycleAsyncApp
+import tornadofx.testapps.MultipleLifecycleAsyncController
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+
+@RunWith(Parameterized::class)
+class AsyncBugAppTest(val rounds: Int) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Int>> {
+            return listOf(arrayOf(1), arrayOf(1))
+        }
+    }
+
+    lateinit var robot: FxRobot
+    lateinit var app: App
+
+    @RelaxedMockK
+    lateinit var controller: MultipleLifecycleAsyncController
+
+    @Rule
+    @JvmField
+    val timeout = Timeout(10, TimeUnit.SECONDS)
+
+    @Before
+    fun before() {
+        MockKAnnotations.init(this)
+
+        FxToolkit.registerPrimaryStage()
+        app = MultipleLifecycleAsyncApp()
+        app.scope.set(controller)
+        FxToolkit.setupApplication { app }
+        robot = FxRobot()
+
+        println("rounds = $rounds")
+    }
+
+    @After
+    fun after() {
+        FxToolkit.cleanupStages()
+        FxToolkit.cleanupApplication(app)
+    }
+
+    @Test()
+    fun itShouldSurviveRunAsyncMultipleTimes() {
+        val latch = CountDownLatch(rounds)
+        every { controller.onAction(any()) }.answers { latch.countDown() }
+
+        var i = 0
+        while (i < rounds) {
+            robot.clickOn("#bug")
+            i++
+        }
+
+        latch.await()
+        verify(exactly = rounds) { controller.onAction(any()) }
+    }
+}

--- a/src/test/kotlin/tornadofx/tests/PersonPoko.kt
+++ b/src/test/kotlin/tornadofx/tests/PersonPoko.kt
@@ -1,0 +1,6 @@
+package tornadofx.tests
+
+data class PersonPoko(var name: String, var phone: String?, var email: String?, var age: Int, var parent: PersonPoko?) {
+    constructor(name: String, age: Int) : this(name, null, null, age, null)
+    constructor() : this("", 18)
+}

--- a/src/test/kotlin/tornadofx/tests/ScopeTest.kt
+++ b/src/test/kotlin/tornadofx/tests/ScopeTest.kt
@@ -59,7 +59,6 @@ class ScopeTest {
 
         val f3 = find<F>(scope2)
 
-        assertTrue(f1.scope.model is PersonModel)
         assertNotEquals(f1.c, f3.c)
         assertNotEquals(f1.vm, f3.vm)
     }

--- a/src/test/kotlin/tornadofx/tests/StylesheetErrorTest.kt
+++ b/src/test/kotlin/tornadofx/tests/StylesheetErrorTest.kt
@@ -1,21 +1,44 @@
 package tornadofx.tests
 
 import javafx.stage.Stage
-import org.testfx.framework.junit.ApplicationTest
-import tornadofx.testapps.StylesheetErrorTest
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+import org.testfx.api.FxAssert.verifyThat
+import org.testfx.api.FxToolkit
+import org.testfx.matcher.control.LabeledMatchers.hasText
+import tornadofx.*
+import tornadofx.testapps.Styles
+import tornadofx.testapps.StylesheetErrorView
 
-class StylesheetErrorTest : ApplicationTest() {
+//@Ignore
+class StylesheetErrorTest {
 
-    /**
-     * This will cause a stylesheet error, but should not crash the application.
-     */
-    override fun start(stage: Stage) {
-        StylesheetErrorTest().start(stage)
-    }
+	companion object {
 
-//    @Test
-//    fun shouldStartApplicationWithWrongStylesheetWithoutCrashing() {
-//        verifyThat(".my-button", hasText("Click here"))
-//    }
+		val app = App(StylesheetErrorView::class, Styles::class)
+		@JvmStatic
+		@BeforeClass
+		fun before() {
+			val primaryStage: Stage = FxToolkit.registerPrimaryStage()
+			/**
+			 * This will cause a stylesheet error, but should not crash the application.
+			 */
+			FX.registerApplication(FxToolkit.setupApplication {
+				app
+			}, primaryStage)
+		}
+
+		@JvmStatic
+		@AfterClass
+		fun after() {
+			FxToolkit.cleanupApplication(app)
+		}
+	}
+
+	@Test
+	fun shouldStartApplicationWithWrongStylesheetWithoutCrashing() {
+		verifyThat(".my-button", hasText("Click here"))
+	}
 
 }

--- a/src/test/kotlin/tornadofx/tests/StylesheetTest.kt
+++ b/src/test/kotlin/tornadofx/tests/StylesheetTest.kt
@@ -1,7 +1,8 @@
 package tornadofx.tests
 
 import javafx.css.PseudoClass
-import javafx.scene.control.Label
+import javafx.css.Styleable
+import javafx.scene.control.*
 import javafx.scene.effect.BlurType
 import javafx.scene.effect.InnerShadow
 import javafx.scene.layout.Pane
@@ -505,15 +506,17 @@ class StylesheetTest {
 
     @Test
     fun inlineStyle() {
-        val node = Pane()
-        node.style {
-            backgroundColor += Color.RED
+        val arrayOfStyleables = arrayOf<Styleable>(Pane(), MenuItem("Click Me"), Tooltip("Click"), Tab("This Tab"), TableColumn<Int, String>())
+        for (node in arrayOfStyleables) {
+            node.style {
+                backgroundColor += Color.RED
+            }
+            assertEquals("-fx-background-color: rgba(255, 0, 0, 1);", node.style)
+            node.style(append = true) {
+                padding = box(10.px)
+            }
+            assertEquals("-fx-background-color: rgba(255, 0, 0, 1); -fx-padding: 10px 10px 10px 10px;", node.style)
         }
-        assertEquals("-fx-background-color: rgba(255, 0, 0, 1);", node.style)
-        node.style(append = true) {
-            padding = box(10.px)
-        }
-        assertEquals("-fx-background-color: rgba(255, 0, 0, 1); -fx-padding: 10px 10px 10px 10px;", node.style)
     }
 
     @Test

--- a/src/test/resources/META-INF/services/tornadofx.ChildInterceptor
+++ b/src/test/resources/META-INF/services/tornadofx.ChildInterceptor
@@ -1,0 +1,2 @@
+tornadofx.tests.FirstInterceptor
+tornadofx.tests.SecondInterceptor


### PR DESCRIPTION
@edvin This updates your jdk9 branch to the current master branch. Let me know if you have an idea for the currently open/unsolved issues listed below.
This compiles and works with the JavaFX application I'm working on (except for the unimplemented issues below, of course)

This is a PR to merge the current master into the jdk9 branch.
Changes:
- Use java.json module to work with Java 9

Unsure:
- Async.kt uses the Platform class now instead of the internal com.sun.glass.ui.Application. IMHO this is ok after looking at the the JDK code , but I'm not expert enough in JavaFX to be sure (internal event thread vs. FX user dispatch thread)

Open issues:
- export of tornadofx.osgi is currently disabled in module-info.java, was required to make the javadoc build step work
- Unsure if sun.net.www.protocol.css should be published in module-info.java
- SmartResize.kt: Resize to fit to content is currently disabled as Java 9 hides the called methods / classes
- ItemControls.kt was using TableRowSkin from the non-public com.sun.* package, it's now using the (newly added?) `javafx.scene.control.skin.TableRowSkinBase` but still has unimplemented methods. Not sure wat the best fix for this is...