### PR TITLE
Replaced some `!!` operators with val, ?.let, non-platform types or more meaningful exceptions

### DIFF
--- a/src/main/java/tornadofx/Animation.kt
+++ b/src/main/java/tornadofx/Animation.kt
@@ -5,6 +5,7 @@ import javafx.beans.value.WritableValue
 import javafx.event.ActionEvent
 import javafx.event.EventHandler
 import javafx.geometry.Point2D
+import javafx.geometry.Point3D
 import javafx.scene.Node
 import javafx.scene.layout.Background
 import javafx.scene.layout.BackgroundFill
@@ -645,7 +646,7 @@ abstract class ViewTransition {
      */
     class FadeThrough(duration: Duration, val color: Paint = Color.TRANSPARENT) : ViewTransition() {
         private val bg = Pane().apply { background = Background(BackgroundFill(color, null, null)) }
-        val halfTime = duration.divide(2.0)!!
+        val halfTime: Duration = duration.divide(2.0)
         override fun create(current: Node, replacement: Node, stack: StackPane)
                 = current.fade(halfTime, 0, easing = Interpolator.EASE_IN, play = false)
                 .then(replacement.fade(halfTime, 0, easing = Interpolator.EASE_OUT, reversed = true, play = false))
@@ -834,8 +835,8 @@ abstract class ViewTransition {
      * @param vertical Whether to flip the card vertically or horizontally
      */
     class Flip(duration: Duration, vertical: Boolean = false) : ViewTransition() {
-        val halfTime = duration.divide(2.0)!!
-        val targetAxis = (if (vertical) Rotate.X_AXIS else Rotate.Y_AXIS)!!
+        val halfTime: Duration = duration.divide(2.0)
+        val targetAxis: Point3D = (if (vertical) Rotate.X_AXIS else Rotate.Y_AXIS)
 
         override fun create(current: Node, replacement: Node, stack: StackPane): Animation {
             return current.rotate(halfTime, 90, easing = Interpolator.EASE_IN, play = false) {

--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -43,7 +43,7 @@ open class App(open val primaryView: KClass<out UIComponent> = NoPrimaryViewSpec
      * Path for the application wide config element. It is `app.properties` by default,
      * in the folder provided by #configBasePath
      */
-    override val configPath: Path get() = configBasePath.resolve("app.properties")!!
+    override val configPath: Path get() = configBasePath.resolve("app.properties")
 
     private val trayIcons = ArrayList<TrayIcon>()
     val resources: ResourceLookup by lazy {

--- a/src/main/java/tornadofx/Async.kt
+++ b/src/main/java/tornadofx/Async.kt
@@ -360,7 +360,8 @@ class MaskPane : BorderPane() {
         center = progressindicator()
     }
 
-    override fun getUserAgentStylesheet() = MaskPane::class.java.getResource("maskpane.css").toExternalForm()!!
+    override fun getUserAgentStylesheet(): String =
+            MaskPane::class.java.getResource("maskpane.css").toExternalForm()
 }
 
 /**

--- a/src/main/java/tornadofx/CSS.kt
+++ b/src/main/java/tornadofx/CSS.kt
@@ -1303,7 +1303,7 @@ fun c(red: Int, green: Int, blue: Int, opacity: Double = 1.0): Color = try {
     Color.MAGENTA
 }
 
-fun Color.derive(ratio: Double) = if (ratio < 0) interpolate(Color(0.0, 0.0, 0.0, opacity), -ratio)!! else interpolate(Color(1.0, 1.0, 1.0, opacity), ratio)!!
+fun Color.derive(ratio: Double): Color = if (ratio < 0) interpolate(Color(0.0, 0.0, 0.0, opacity), -ratio) else interpolate(Color(1.0, 1.0, 1.0, opacity), ratio)
 
 fun Color.ladder(vararg stops: Stop): Color {
     val offset = brightness

--- a/src/main/java/tornadofx/DataGrid.kt
+++ b/src/main/java/tornadofx/DataGrid.kt
@@ -465,8 +465,8 @@ class DataGridRowSkin<T>(control: DataGridRow<T>) : CellSkinBase<DataGridRow<T>,
 }
 
 class DataGridSelectionModel<T>(val dataGrid: DataGrid<T>) : MultipleSelectionModel<T>() {
-    private val selectedIndicies = FXCollections.observableArrayList<Int>()
-    private val selectedItems = FXCollections.observableArrayList<T>()
+    private val selectedIndicies: ObservableList<Int> = FXCollections.observableArrayList()
+    private val selectedItems: ObservableList<T> = FXCollections.observableArrayList()
 
     fun getCellAt(index: Int): DataGridCell<T>? {
         val skin = dataGrid.skin as DataGridSkin<T>

--- a/src/main/java/tornadofx/Decoration.kt
+++ b/src/main/java/tornadofx/Decoration.kt
@@ -38,11 +38,8 @@ class SimpleMessageDecorator(val message: String?, severity: ValidationSeverity)
     var tooltip: Tooltip? = null
     var attachedToNode: Node? = null
 
-    @Suppress("ObjectLiteralToLambda") // Must remain object literal or else removeListener doesn't match
-    var focusListener = object : ChangeListener<Boolean> {
-        override fun changed(observable: ObservableValue<out Boolean>?, oldValue: Boolean?, newValue: Boolean?) {
-            if (newValue == true) showTooltip(attachedToNode!!) else tooltip?.hide()
-        }
+    var focusListener = ChangeListener<Boolean> { _, _, newValue ->
+        if (newValue == true) showTooltip(attachedToNode!!) else tooltip?.hide()
     }
 
     override fun decorate(node: Node) {

--- a/src/main/java/tornadofx/FX.kt
+++ b/src/main/java/tornadofx/FX.kt
@@ -57,12 +57,9 @@ open class Scope() {
     val hasActiveWorkspace: Boolean get() = workspaceInstance != null
 
     var workspace: Workspace
-        get() {
-            if (workspaceInstance == null) {
-                // Use configured default workspace
-                workspaceInstance = find(FX.defaultWorkspace, this)
-            }
-            return workspaceInstance!!
+        get() = workspaceInstance ?: find(FX.defaultWorkspace, this).also {
+            // Use configured default workspace
+            workspaceInstance = it
         }
         set(value) {
             workspaceInstance = value

--- a/src/main/java/tornadofx/Forms.kt
+++ b/src/main/java/tornadofx/Forms.kt
@@ -67,8 +67,8 @@ open class Form : VBox() {
 
     internal val fieldsets = HashSet<Fieldset>()
 
-    override fun getUserAgentStylesheet() =
-            Form::class.java.getResource("form.css").toExternalForm()!!
+    override fun getUserAgentStylesheet(): String =
+            Form::class.java.getResource("form.css").toExternalForm()
 }
 
 @DefaultProperty("children")
@@ -189,7 +189,7 @@ open class Fieldset(text: String? = null, labelPosition: Orientation = HORIZONTA
         HBox.setHgrow(input, inputGrow)
     }
 
-    val form: Form get() = findParent<Form>()!!
+    val form: Form get() = findParent() ?: kotlin.error("FieldSet should be a child of Form node")
 
     internal val fields = HashSet<Field>()
 
@@ -264,7 +264,7 @@ abstract class AbstractField(text: String? = null, val forceLabelIndent: Boolean
         children.add(labelContainer)
     }
 
-    val fieldset: Fieldset get() = findParent()!!
+    val fieldset: Fieldset get() = findParent() ?: kotlin.error("Field should be a child of FieldSet node")
 
     override fun computePrefHeight(width: Double): Double {
         val labelHasContent = forceLabelIndent || !labelProperty.value.isNullOrBlank()

--- a/src/main/java/tornadofx/InternalWindow.kt
+++ b/src/main/java/tornadofx/InternalWindow.kt
@@ -128,7 +128,7 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
         }
     }
 
-    override fun getUserAgentStylesheet() = URL("css://${Styles::class.java.name}").toExternalForm()!!
+    override fun getUserAgentStylesheet(): String = URL("css://${Styles::class.java.name}").toExternalForm()
 
     fun fillOverlay() {
         overlay?.graphicsContext2D.apply {
@@ -147,13 +147,15 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
 
         coverNode.uiComponent<UIComponent>()?.muteDocking = true
 
+        val coverParent = this.coverParent
         if (coverParent != null) {
-            indexInCoverParent = coverParent!!.getChildList()!!.indexOf(owner)
-            owner.removeFromParent()
-            coverParent!!.getChildList()!!.add(indexInCoverParent!!, this)
+            val childList = coverParent.getChildList() ?: kotlin.error("Can't reach children of owner parent")
+            indexInCoverParent = childList.indexOf(owner).also { index ->
+                owner.removeFromParent()
+                childList.add(index, this)
+            }
         } else {
-            val scene = owner.scene
-            scene.root = this
+            owner.scene.root = this
         }
 
         coverNode.uiComponent<UIComponent>()?.muteDocking = false
@@ -170,8 +172,10 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
 
         coverNode.removeFromParent()
         removeFromParent()
+        val indexInCoverParent = this.indexInCoverParent
         if (indexInCoverParent != null) {
-            coverParent!!.getChildList()!!.add(indexInCoverParent!!, coverNode)
+            val childList = coverParent!!.getChildList() ?: kotlin.error("Can't reach children of owner parent")
+            childList.add(indexInCoverParent, coverNode)
         } else {
             scene?.root = coverNode as Parent?
         }
@@ -218,5 +222,4 @@ class InternalWindow(icon: Node?, modal: Boolean, escapeClosesWindow: Boolean, c
             window.top.layoutY += mouseEvent.y - y
         }
     }
-
 }

--- a/src/main/java/tornadofx/ItemControls.kt
+++ b/src/main/java/tornadofx/ItemControls.kt
@@ -261,14 +261,12 @@ class LazyTreeItem<T : Any>(
         val itemProcessor: (LazyTreeItem<T>) -> Unit = {},
         val childFactory: (TreeItem<T>) -> List<T>?
 ) : TreeItem<T>(value) {
-    var leafResult: Boolean? = null
+    private val leafResult: Boolean by lazy { leafCheck(this) }
     var childFactoryInvoked = false
     var childFactoryResult: List<T>? = null
 
     override fun isLeaf(): Boolean {
-        if (leafResult == null)
-            leafResult = leafCheck(this)
-        return leafResult!!
+        return leafResult
     }
 
     override fun getChildren(): ObservableList<TreeItem<T>> {
@@ -311,8 +309,11 @@ class LazyTreeItem<T : Any>(
     private fun invokeAndSetChildFactorySynchronously(): List<T>? {
         if (!childFactoryInvoked) {
             childFactoryInvoked = true
-            childFactoryResult = childFactory(this)
-            if (childFactoryResult != null) super.getChildren().setAll(childFactoryResult!!.map { newLazyTreeItem(it) })
+            childFactoryResult = childFactory(this).also { result ->
+                if(result != null) {
+                    super.getChildren().setAll(result.map { newLazyTreeItem(it) })
+                }
+            }
         }
         return childFactoryResult
     }
@@ -921,21 +922,13 @@ val <S> TableView<S>.editModel: TableViewEditModel<S>
 class TableViewEditModel<S>(val tableView: TableView<S>) {
     val items = FXCollections.observableHashMap<S, TableColumnDirtyState<S>>()
 
-    private var _selectedItemDirtyState: ObjectBinding<TableColumnDirtyState<S>?>? = null
-    val selectedItemDirtyState: ObjectBinding<TableColumnDirtyState<S>?>
-        get() {
-            if (_selectedItemDirtyState == null)
-                _selectedItemDirtyState = objectBinding(tableView.selectionModel.selectedItemProperty()) { getDirtyState(value) }
-            return _selectedItemDirtyState!!
-        }
+    val selectedItemDirtyState: ObjectBinding<TableColumnDirtyState<S>?> by lazy {
+        objectBinding(tableView.selectionModel.selectedItemProperty()) { getDirtyState(value) }
+    }
 
-    private var _selectedItemDirty: BooleanBinding? = null
-    val selectedItemDirty: BooleanBinding
-        get() {
-            if (_selectedItemDirty == null)
-                _selectedItemDirty = booleanBinding(selectedItemDirtyState) { value?.dirty?.value ?: false }
-            return _selectedItemDirty!!
-        }
+    val selectedItemDirty: BooleanBinding by lazy {
+        booleanBinding(selectedItemDirtyState) { value?.dirty?.value ?: false }
+    }
 
     fun getDirtyState(item: S): TableColumnDirtyState<S> = items.getOrPut(item) { TableColumnDirtyState(this, item) }
 
@@ -1045,13 +1038,7 @@ class TableColumnDirtyState<S>(val editModel: TableViewEditModel<S>, val item: S
             return _dirtyColumns!!
         }
 
-    private var _dirty: BooleanBinding? = null
-    val dirty: BooleanBinding
-        get() {
-            if (_dirty == null)
-                _dirty = booleanBinding(dirtyColumns) { isNotEmpty() }
-            return _dirty!!
-        }
+    val dirty: BooleanBinding by lazy { booleanBinding(dirtyColumns) { isNotEmpty() } }
     val isDirty: Boolean get() = dirty.value
 
     fun getDirtyColumnProperty(column: TableColumn<*, *>) = booleanBinding(dirtyColumns) { containsKey(column as TableColumn<S, Any?>) }

--- a/src/main/java/tornadofx/LayoutDebugger.kt
+++ b/src/main/java/tornadofx/LayoutDebugger.kt
@@ -63,7 +63,7 @@ class LayoutDebugger : Fragment() {
 
     private fun hookListeners() {
         nodeTree.selectionModel.selectedItemProperty().onChange {
-            if (it?.value != null) setSelectedNode(it!!.value.node)
+            if (it?.value != null) setSelectedNode(it.value.node)
         }
 
         // Position overlay over hovered node

--- a/src/main/java/tornadofx/Lib.kt
+++ b/src/main/java/tornadofx/Lib.kt
@@ -216,6 +216,9 @@ fun Clipboard.putString(value: String) = setContent { putString(value) }
 fun Clipboard.putFiles(files: MutableList<File>) = setContent { putFiles(files) }
 fun Clipboard.put(dataFormat: DataFormat, value: Any) = setContent { put(dataFormat, value) }
 
+inline fun <T> ChangeListener(crossinline listener: (observable: ObservableValue<out T>?, oldValue: T, newValue: T) -> Unit): ChangeListener<T> =
+        javafx.beans.value.ChangeListener<T> { observable, oldValue, newValue -> listener(observable, oldValue, newValue) }
+
 /**
  * Listen for changes to this observable. Optionally only listen x times.
  * The lambda receives the changed value when the change occurs, which may be null,

--- a/src/main/java/tornadofx/ListMenu.kt
+++ b/src/main/java/tornadofx/ListMenu.kt
@@ -191,7 +191,7 @@ class ListMenuItemSkin(control: ListMenuItem) : SkinBase<ListMenuItem>(control) 
         text.textProperty().bind(control.textProperty)
         children.add(text)
 
-        if (skinnable.graphic != null) registerGraphic(skinnable.graphic!!)
+        skinnable.graphic?.let { registerGraphic(it) }
 
         skinnable.graphicProperty.addListener { _, old, new ->
             if (old != null) children.remove(old)
@@ -207,8 +207,8 @@ class ListMenuItemSkin(control: ListMenuItem) : SkinBase<ListMenuItem>(control) 
     override fun computePrefWidth(height: Double, topInset: Double, rightInset: Double, bottomInset: Double, leftInset: Double): Double {
         var w = if (text.text.isNullOrBlank()) 0.0 else text.prefWidth(height)
 
-        if (skinnable.graphic != null) {
-            val graphicSize = Math.max(skinnable.graphic!!.prefWidth(-1.0), graphicFixedSize)
+        skinnable.graphic?.let { graphic ->
+            val graphicSize = Math.max(graphic.prefWidth(-1.0), graphicFixedSize)
             if (iconPosition.isVertical)
                 w += graphicSize
             else
@@ -221,8 +221,8 @@ class ListMenuItemSkin(control: ListMenuItem) : SkinBase<ListMenuItem>(control) 
     override fun computePrefHeight(width: Double, topInset: Double, rightInset: Double, bottomInset: Double, leftInset: Double): Double {
         var h = if (text.text.isNullOrBlank()) 0.0 else text.prefHeight(width)
 
-        if (skinnable.graphic != null) {
-            val graphicSize = Math.max(skinnable.graphic!!.prefHeight(-1.0), graphicFixedSize)
+        skinnable.graphic?.let { graphic ->
+            val graphicSize = Math.max(graphic.prefHeight(-1.0), graphicFixedSize)
             if (iconPosition.isHorizontal)
                 h += graphicSize
             else

--- a/src/main/java/tornadofx/ListView.kt
+++ b/src/main/java/tornadofx/ListView.kt
@@ -27,13 +27,15 @@ import kotlin.reflect.KClass
  */
 fun <T> ListView<T>.onUserSelect(clickCount: Int = 2, action: (T) -> Unit) {
     addEventFilter(MouseEvent.MOUSE_CLICKED) { event ->
+        val selectedItem = this.selectedItem
         if (event.clickCount == clickCount && selectedItem != null && event.target.isInsideRow())
-            action(selectedItem!!)
+            action(selectedItem)
     }
 
     addEventFilter(KeyEvent.KEY_PRESSED) { event ->
+        val selectedItem = this.selectedItem
         if (event.code == KeyCode.ENTER && !event.isMetaDown && selectedItem != null)
-            action(selectedItem!!)
+            action(selectedItem)
     }
 }
 
@@ -44,10 +46,11 @@ fun <T> ListView<T>.asyncItems(func: () -> Collection<T>) =
         task { func() } success { if (items == null) items = FXCollections.observableArrayList(it) else items.setAll(it) }
 
 fun <T> ListView<T>.onUserDelete(action: (T) -> Unit) {
-    addEventFilter(KeyEvent.KEY_PRESSED, { event ->
+    addEventFilter(KeyEvent.KEY_PRESSED) { event ->
+        val selectedItem = this.selectedItem
         if (event.code == KeyCode.BACK_SPACE && selectedItem != null)
-            action(selectedItem!!)
-    })
+            action(selectedItem)
+    }
 }
 
 class ListCellCache<T>(private val cacheProvider: (T) -> Node) {

--- a/src/main/java/tornadofx/Menu.kt
+++ b/src/main/java/tornadofx/Menu.kt
@@ -285,17 +285,13 @@ fun EventTarget.contextmenu(op: ContextMenu.() -> Unit = {}) = apply {
  */
 fun EventTarget.lazyContextmenu(op: ContextMenu.() -> Unit = {}) = apply {
     var currentMenu: ContextMenu? = null
-    (this as? Node)?.apply {
-        setOnContextMenuRequested { event ->
-            currentMenu?.hide()
-
-            currentMenu = ContextMenu()
-            currentMenu!!.also {
-                it.setOnCloseRequest { currentMenu = null }
-                op(it)
-                it.show(this, event.screenX, event.screenY)
-            }
-            event.consume()
+    (this as? Node)?.setOnContextMenuRequested { event ->
+        currentMenu?.hide()
+        currentMenu = ContextMenu().also {
+            it.setOnCloseRequest { currentMenu = null }
+            op(it)
+            it.show(this, event.screenX, event.screenY)
         }
+        event.consume()
     }
 }

--- a/src/main/java/tornadofx/Messages.kt
+++ b/src/main/java/tornadofx/Messages.kt
@@ -34,9 +34,9 @@ object FXResourceBundleControl : ResourceBundle.Control() {
                 if (ResourceBundle::class.java.isAssignableFrom(bundleClass)) bundleClass.newInstance()
                 else throw ClassCastException(bundleClass.name + " cannot be cast to ResourceBundle")
 
-            } catch (e: ClassNotFoundException) { null}
+            } catch (e: ClassNotFoundException) { null }
             "java.properties" -> {
-                val resourceName = toResourceName(bundleName, "properties")!!
+                val resourceName: String = toResourceName(bundleName, "properties")
                 doPrivileged<IOException, InputStream?> {
                     if (!reload) loader.getResourceAsStream(resourceName)
                     else loader.getResource(resourceName)?.openConnection()?.apply {

--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -1195,13 +1195,13 @@ class SVGIcon(svgShape: String, size: Number = 16, color: Paint = Color.BLACK) :
 internal class ShortLongPressHandler(node: Node) {
     var holdTimer = PauseTransition(700.millis)
     var consume: Boolean = false
-    var originatingEvent: MouseEvent? = null
+    lateinit var originatingEvent: MouseEvent
 
     var shortAction: ((MouseEvent) -> Unit)? = null
     var longAction: ((MouseEvent) -> Unit)? = null
 
     init {
-        holdTimer.setOnFinished { longAction?.invoke(originatingEvent!!) }
+        holdTimer.setOnFinished { longAction?.invoke(originatingEvent) }
 
         node.addEventHandler(MouseEvent.MOUSE_PRESSED) {
             originatingEvent = it
@@ -1212,7 +1212,7 @@ internal class ShortLongPressHandler(node: Node) {
         node.addEventHandler(MouseEvent.MOUSE_RELEASED) {
             if (holdTimer.status == Animation.Status.RUNNING) {
                 holdTimer.stop()
-                shortAction?.invoke(originatingEvent!!)
+                shortAction?.invoke(originatingEvent)
                 if (consume) it.consume()
             }
         }

--- a/src/main/java/tornadofx/Slideshow.kt
+++ b/src/main/java/tornadofx/Slideshow.kt
@@ -95,10 +95,10 @@ class Slideshow(val scope: Scope = DefaultScope) : BorderPane() {
     }
 
     class Slide(val view: KClass<out UIComponent>, val transition: ViewTransition? = null) {
-        private var ui: UIComponent? = null
+        private lateinit var ui: UIComponent
         fun getUI(scope: Scope): UIComponent {
-            if (ui == null) ui = find(view, scope)
-            return ui!!
+            if (!::ui.isInitialized) ui = find(view, scope)
+            return ui
         }
     }
 }

--- a/src/main/java/tornadofx/TreeView.kt
+++ b/src/main/java/tornadofx/TreeView.kt
@@ -125,15 +125,15 @@ fun <T> TreeView<T>.bindSelected(model: ItemViewModel<T>) = this.bindSelected(mo
 
 fun <T> TreeView<T>.onUserDelete(action: (T) -> Unit) {
     addEventFilter(KeyEvent.KEY_PRESSED, { event ->
-        if (event.code == KeyCode.BACK_SPACE && selectionModel.selectedItem?.value != null)
-            action(selectedValue!!)
+        val value = selectedValue
+        if (event.code == KeyCode.BACK_SPACE && value != null)
+            action(value)
     })
 }
 
 fun <T> TreeView<T>.onUserSelect(action: (T) -> Unit) {
-    selectionModel.selectedItemProperty().addListener { obs, old, new ->
-        if (new != null && new.value != null)
-            action(new.value)
+    selectionModel.selectedItemProperty().addListener { _, _, new ->
+        new?.value?.let { action(it) }
     }
 }
 

--- a/src/main/java/tornadofx/Validation.kt
+++ b/src/main/java/tornadofx/Validation.kt
@@ -152,8 +152,9 @@ class ValidationContext {
             decorator?.apply { undecorate(node) }
             decorator = null
 
-            result = validator(this@ValidationContext, property.value)
-            (valid as BooleanProperty).value = result == null || result!!.severity != ValidationSeverity.Error
+            result = validator(this@ValidationContext, property.value).also {
+                (valid as BooleanProperty).value = it == null || it.severity != ValidationSeverity.Error
+            }
 
             if (decorateErrors) {
                 result?.apply {

--- a/src/main/java/tornadofx/ViewModel.kt
+++ b/src/main/java/tornadofx/ViewModel.kt
@@ -167,7 +167,7 @@ open class ViewModel : Component(), ScopedInstance {
     inline fun <reified T : Any> property(autocommit: Boolean = false, forceObjectProperty: Boolean = false, defaultValue: T? = null, noinline op: () -> Property<T>) = PropertyDelegate(bind(autocommit, forceObjectProperty, defaultValue, op))
 
     val dirtyListener: ChangeListener<Any> = ChangeListener { property, _, newValue ->
-        if (property!! in ignoreDirtyStateProperties) return@ChangeListener
+        if (property in ignoreDirtyStateProperties) return@ChangeListener
 
         val sourceValue = propertyMap[property]!!.invoke()?.value
         if (sourceValue == newValue) {

--- a/src/main/java/tornadofx/adapters/TornadoFXResizeFeatures.kt
+++ b/src/main/java/tornadofx/adapters/TornadoFXResizeFeatures.kt
@@ -23,7 +23,7 @@ interface TornadoFXResizeFeatures<COLUMN, out TABLE : Any> {
 class TornadoFXTreeTableResizeFeatures(val param: TreeTableView.ResizeFeatures<out Any>) : TornadoFXResizeFeatures<TreeTableColumn<*, *>, TreeTableView<*>> {
     override val column = param.column?.toTornadoFXColumn()
     override val table = param.table.toTornadoFXTable()
-    override val delta get() = param.delta!!
+    override val delta: Double get() = param.delta
 }
 
 class TornadoFxTableResizeFeatures(val param: TableView.ResizeFeatures<out Any>) : TornadoFXResizeFeatures<TableColumn<*, *>, TableView<*>> {


### PR DESCRIPTION
There are some places where these weren't needed at all, and in others actual `KotlinNullPointerException` probably may never appear because of the nature of JavaFX single-threaded property access. Nevertheless I've decided to work around some places where this operator is used so that either there are no possibilities for a race condition or user gets some meaningful error message.

Feel free to point me at places which can definitely be left intact :)