### PR TITLE
Redesign the MultipleLifecycleAsyncAppTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,6 @@
             <version>${de.jensd.fontawesomefx.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.mockk</groupId>
-            <artifactId>mockk</artifactId>
-            <version>1.7</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/src/test/kotlin/tornadofx/testapps/MultipleLifecycleAsyncApp.kt
+++ b/src/test/kotlin/tornadofx/testapps/MultipleLifecycleAsyncApp.kt
@@ -1,25 +1,20 @@
 package tornadofx.testapps
 
+import javafx.beans.property.SimpleIntegerProperty
 import tornadofx.*
 
-class MultipleLifecycleAsyncApp : App(MultipleLifecycleAsyncView::class)
-
 class MultipleLifecycleAsyncView : View("Multiple Lifecycle Async") {
-    val controller: MultipleLifecycleAsyncController by inject()
+    val counterProperty = SimpleIntegerProperty()
+    var counter by counterProperty
     override val root = pane {
-        button("Robot-click to repeat bug") {
-            id = "bug"
+        button("Increment on background thread and main thread") {
             action {
                 runAsync {
-                    controller.onAction("button clicked")
+                    counter++
+                } success {
+                    counter++
                 }
             }
         }
-    }
-}
-
-class MultipleLifecycleAsyncController : Controller() {
-    fun onAction(message: String) {
-        println(message)
     }
 }


### PR DESCRIPTION
- Use a property change listener to count down the latch to avoid FX
application thread and test runner thread issues
- Remove mockK dependency