### PR TITLE
Added initialDirectory to chooseFile

### DIFF
--- a/src/main/java/tornadofx/Dialogs.kt
+++ b/src/main/java/tornadofx/Dialogs.kt
@@ -70,7 +70,14 @@ enum class FileChooserMode { None, Single, Multi, Save }
  *
  * If the user cancels, the returnedfile list will be empty.
  */
-fun chooseFile(title: String? = null, filters: Array<FileChooser.ExtensionFilter>, mode: FileChooserMode = Single, owner: Window? = null, op: FileChooser.() -> Unit = {}, initialDirectory: File? = null): List<File> {
+fun chooseFile(title: String? = null, filters: Array<FileChooser.ExtensionFilter>, mode: FileChooserMode = Single, owner: Window? = null, op: FileChooser.() -> Unit = {}): List<File> {
+    return chooseFileFromDirectory(title = title, filters = filters, mode = mode, owner = owner, op = op)
+}
+
+/**
+ * An extended version of chooseFile which allows the user to choose the initial directory to look in for the file.
+ */
+fun chooseFileFromDirectory(title: String? = null, initialDirectory: File? = null, filters: Array<FileChooser.ExtensionFilter>, mode: FileChooserMode = Single, owner: Window? = null, op: FileChooser.() -> Unit = {}): List<File> {
     val chooser = FileChooser()
     if (title != null) chooser.title = title
     if (initialDirectory != null) chooser.initialDirectory = initialDirectory

--- a/src/main/java/tornadofx/Dialogs.kt
+++ b/src/main/java/tornadofx/Dialogs.kt
@@ -70,9 +70,10 @@ enum class FileChooserMode { None, Single, Multi, Save }
  *
  * If the user cancels, the returnedfile list will be empty.
  */
-fun chooseFile(title: String? = null, filters: Array<FileChooser.ExtensionFilter>, mode: FileChooserMode = Single, owner: Window? = null, op: FileChooser.() -> Unit = {}): List<File> {
+fun chooseFile(title: String? = null, filters: Array<FileChooser.ExtensionFilter>, mode: FileChooserMode = Single, owner: Window? = null, op: FileChooser.() -> Unit = {}, initialDirectory: File? = null): List<File> {
     val chooser = FileChooser()
     if (title != null) chooser.title = title
+    if (initialDirectory != null) chooser.initialDirectory = initialDirectory
     chooser.extensionFilters.addAll(filters)
     op(chooser)
     return when (mode) {


### PR DESCRIPTION
This allows specifying an initial directory to look in when using the file chooser.
I added it as the last parameter to avoid breaking code which uses positional arguments.