### PR TITLE
refactor charts

### DIFF
--- a/src/main/java/tornadofx/Charts.kt
+++ b/src/main/java/tornadofx/Charts.kt
@@ -33,68 +33,52 @@ fun PieChart.data(value: Map<String, Double>) = value.forEach { data(it.key, it.
 /**
  * Create a LineChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.linechart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: LineChart<X, Y>.() -> Unit = {}): LineChart<X, Y> {
-    val chart = LineChart(x, y)
-    chart.title = title
-    return opcr(this, chart, op)
-}
+fun <X, Y> EventTarget.linechart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: LineChart<X, Y>.() -> Unit = {}) =
+        LineChart<X, Y>(x, y).attachTo(this, op) { it.title = title }
 
 /**
  * Create an AreaChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.areachart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: AreaChart<X, Y>.() -> Unit = {}): AreaChart<X, Y> {
-    val chart = AreaChart(x, y)
-    chart.title = title
-    return opcr(this, chart, op)
-}
+fun <X, Y> EventTarget.areachart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: AreaChart<X, Y>.() -> Unit = {}) =
+        AreaChart<X,Y>(x, y).attachTo(this, op){ it.title = title }
 
 /**
  * Create a BubbleChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.bubblechart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: BubbleChart<X, Y>.() -> Unit = {}): BubbleChart<X, Y> {
-    val chart = BubbleChart(x, y)
-    chart.title = title
-    return opcr(this, chart, op)
-}
+fun <X, Y> EventTarget.bubblechart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: BubbleChart<X, Y>.() -> Unit = {}) =
+        BubbleChart<X, Y>(x, y).attachTo(this,op){ it.title = title }
 
 /**
  * Create a ScatterChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.scatterchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: ScatterChart<X, Y>.() -> Unit = {}): ScatterChart<X, Y> {
-    val chart = ScatterChart(x, y)
-    chart.title = title
-    return opcr(this, chart, op)
-}
+fun <X, Y> EventTarget.scatterchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: ScatterChart<X, Y>.() -> Unit = {}) =
+        ScatterChart(x, y).attachTo(this,op){ it.title = title }
 
 /**
  * Create a BarChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.barchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: BarChart<X, Y>.() -> Unit = {}): BarChart<X, Y> {
-    val chart = BarChart(x, y)
-    chart.title = title
-    return opcr(this, chart, op)
-}
+fun <X, Y> EventTarget.barchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: BarChart<X, Y>.() -> Unit = {}) =
+        BarChart<X, Y>(x, y).attachTo(this, op){ it.title = title }
 
 /**
  * Create a BarChart with optional title, axis and add to the parent pane. The optional op will be performed on the new instance.
  */
-fun <X, Y> EventTarget.stackedbarchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: StackedBarChart<X, Y>.() -> Unit = {}): StackedBarChart<X, Y> {
-    val chart = StackedBarChart(x, y)
-    chart.title = title
-    return opcr(this, chart, op)
-}
+fun <X, Y> EventTarget.stackedbarchart(title: String? = null, x: Axis<X>, y: Axis<Y>, op: StackedBarChart<X, Y>.() -> Unit = {}) =
+        StackedBarChart<X, Y>(x, y).attachTo(this, op) { it.title = title }
 
 /**
  * Add a new XYChart.Series with the given name to the given Chart. Optionally specify a list data for the new series or
  * add data with the optional op that will be performed on the created series object.
  */
-fun <X, Y, ChartType : XYChart<X, Y>> ChartType.series(name: String, elements: ObservableList<XYChart.Data<X, Y>>? = null, op: (XYChart.Series<X, Y>).() -> Unit = {}): XYChart.Series<X, Y> {
-    val series = XYChart.Series<X, Y>()
-    series.name = name
-    if (elements != null) series.data = elements
-    op(series)
-    data.add(series)
-    return series
+fun <X, Y, ChartType : XYChart<X, Y>> ChartType.series(
+        name: String,
+        elements: ObservableList<XYChart.Data<X, Y>>? = null,
+        op: (XYChart.Series<X, Y>).() -> Unit = {}
+) = XYChart.Series<X, Y>().also {
+    it.name = name
+    elements?.let (it::setData)
+    op(it)
+    data.add(it)
 }
 
 /**
@@ -113,28 +97,24 @@ fun <X, Y> XYChart.Series<X, Y>.data(x: X, y: Y, extra: Any? = null, op: (XYChar
  * Helper class for the multiseries support
  */
 class MultiSeries<X, Y>(val series: List<XYChart.Series<X, Y>>, val chart: XYChart<X, Y>) {
-    fun data(x: X, vararg y: Y) {
-        for ((index, value) in y.withIndex())
-            series[index].data(x, value)
-    }
+    fun data(x: X, vararg y: Y) = y.forEachIndexed { index, value -> series[index].data(x, value) }
 }
 
 /**
  * Add multiple series XYChart.Series with data in one go. Specify a list of names for the series
  * and then add values in the op. Example:
- * <pre>
- * multiseries("Portfolio 1", "Portfolio 2") {
- *   data(1, 23, 10)
- *   data(2, 14, 5)
- *   data(3, 15, 8)
- *   ...
- * }
- * </pre>
+ *
+ *     multiseries("Portfolio 1", "Portfolio 2") {
+ *         data(1, 23, 10)
+ *         data(2, 14, 5)
+ *         data(3, 15, 8)
+ *         ...
+ *     }
+ *
  */
 fun <X, Y, ChartType : XYChart<X, Y>> ChartType.multiseries(vararg names: String, op: (MultiSeries<X, Y>).() -> Unit = {}): MultiSeries<X, Y> {
     val series = names.map { XYChart.Series<X, Y>().apply { name = it } }
-    val multiseries = MultiSeries(series, this)
-    op(multiseries)
+    val multiSeries = MultiSeries(series, this).also(op)
     data.addAll(series)
-    return multiseries
+    return multiSeries
 }

--- a/src/main/java/tornadofx/FX.kt
+++ b/src/main/java/tornadofx/FX.kt
@@ -449,6 +449,10 @@ inline fun <T : Node> opcr(parent: EventTarget, node: T, op: T.() -> Unit = {}) 
  */
 inline fun <T : Node> T.attachTo(parent: EventTarget, op: T.() -> Unit = {}): T = opcr(parent, this, op)
 
+/**
+ * Attaches the node to the pane and invokes the node operation.
+ * Because the framework sometimes needs to setup the node, another lambda can be provided
+ */
 internal inline fun <T : Node> T.attachTo(
         parent: EventTarget,
         after: T.() -> Unit,


### PR DESCRIPTION
- use attachTo more
- fixes pre, Dokka/KDOC uses 4 spaces or 3 tildes
- uses foreachindexed instead of for + withindex