### PR TITLE
Fixed ValidationTrigger.OnChange.equals() not working properly

### DIFF
--- a/src/main/java/tornadofx/Validation.kt
+++ b/src/main/java/tornadofx/Validation.kt
@@ -16,7 +16,7 @@ enum class ValidationSeverity { Error, Warning, Info, Success }
 
 sealed class ValidationTrigger {
     object OnBlur : ValidationTrigger()
-    class OnChange(val delay: Long = 0) : ValidationTrigger()
+    data class OnChange(val delay: Long = 0) : ValidationTrigger()
     object None : ValidationTrigger()
 }
 


### PR DESCRIPTION
I have a list of custom validators and a need to group them by its trigger, but the only ones that group correctly are `ValidationTrigger.None` and `ValidationTrigger.OnBlur`, all the rest of `ValidationTrigger.OnChange` triggers are grouped in lists of one element each because the `delay` property is not taken into account when calling `equals()`
### Test code:
```kotlin
fun main(args: Array<String>) {
    println(ValidationTrigger.OnChange())
    println(ValidationTrigger.OnChange() == ValidationTrigger.OnChange())
}
```
### Result before:
```
tornadofx.ValidationTrigger$OnChange@5e481248
false
```
### Result after:
```
OnChange(delay=0)
true
```