### PR TITLE
`onCancel()` is now called when reusing Wizard instance (#735)

### DIFF
--- a/src/main/java/tornadofx/Wizard.kt
+++ b/src/main/java/tornadofx/Wizard.kt
@@ -220,9 +220,17 @@ abstract class Wizard @JvmOverloads constructor(title: String? = null, heading: 
         }
 
         runLater {
+            // For when the instance is created
             currentStage?.setOnCloseRequest {
                 it.consume()
                 onCancel()
+            }
+            // For when the instance is reused and the stage is changed
+            root.sceneProperty().select { it.windowProperty() }.onChange {
+                it?.setOnCloseRequest {
+                    it.consume()
+                    onCancel()
+                }
             }
         }
     }


### PR DESCRIPTION
Fix for #735, now each time the scene changes the `OnCloseRequest` is reset, so when pressing the X close button the `onCancel()` function is called even if the Wizard instance is reused.

PS: This is a quick fix I came up with, maybe it can be improved