### PR TITLE
Provide a possibility to customize the charset of properties file

### DIFF
--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -12,6 +12,7 @@ import java.awt.event.*
 import java.awt.event.MouseEvent.BUTTON1
 import java.awt.image.BufferedImage
 import java.io.InputStream
+import java.nio.charset.Charset
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
@@ -44,6 +45,8 @@ open class App(open val primaryView: KClass<out UIComponent> = NoPrimaryViewSpec
      * in the folder provided by #configBasePath
      */
     override val configPath: Path get() = configBasePath.resolve("app.properties")
+
+    override val configCharset: Charset get() = Charsets.UTF_8
 
     private val trayIcons = ArrayList<TrayIcon>()
     val resources: ResourceLookup by lazy {

--- a/src/main/java/tornadofx/Component.kt
+++ b/src/main/java/tornadofx/Component.kt
@@ -35,8 +35,10 @@ import javafx.stage.Window
 import javafx.util.Duration
 import java.io.Closeable
 import java.io.InputStream
+import java.io.InputStreamReader
 import java.io.StringReader
 import java.net.URL
+import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.*
@@ -54,10 +56,12 @@ interface ScopedInstance
 interface Configurable {
     val config: ConfigProperties
     val configPath: Path
+    val configCharset: Charset
 
     fun loadConfig() = ConfigProperties(this).apply {
-        if (Files.exists(configPath))
-            Files.newInputStream(configPath).use { load(it) }
+        if (Files.exists(configPath)) {
+            Files.newInputStream(configPath).use { load(InputStreamReader(it, configCharset)) }
+        }
     }
 }
 
@@ -109,6 +113,7 @@ abstract class Component : Configurable {
      */
     override val configPath: Path get() = app.configBasePath.resolve("${javaClass.name}.properties")
     override val config: ConfigProperties by lazy { loadConfig() }
+    override val configCharset: Charset get() = Charsets.UTF_8
 
     val clipboard: Clipboard by lazy { Clipboard.getSystemClipboard() }
     val hostServices: HostServices by lazy { FX.application.hostServices }


### PR DESCRIPTION
Resolves #831 

Set the default charset for properties files to UTF-8.