### PR TITLE
Don't start a new thread for each runLater(duration)

### DIFF
--- a/src/main/java/tornadofx/Async.kt
+++ b/src/main/java/tornadofx/Async.kt
@@ -158,6 +158,8 @@ infix fun <T> Task<T>.cancel(func: () -> Unit) = apply {
  */
 fun runLater(op: () -> Unit) = Platform.runLater(op)
 
+private val timer: Timer by lazy { Timer(true) }
+
 /**
  * Run the specified Runnable on the JavaFX Application Thread after a
  * specified delay.
@@ -170,7 +172,6 @@ fun runLater(op: () -> Unit) = Platform.runLater(op)
  * You can cancel the task before the time is up to abort the execution.
  */
 fun runLater(delay: Duration, op: () -> Unit): FXTimerTask {
-    val timer = Timer(true)
     val task = FXTimerTask(op, timer)
     timer.schedule(task, delay.toMillis().toLong())
     return task

--- a/src/main/java/tornadofx/Async.kt
+++ b/src/main/java/tornadofx/Async.kt
@@ -158,7 +158,7 @@ infix fun <T> Task<T>.cancel(func: () -> Unit) = apply {
  */
 fun runLater(op: () -> Unit) = Platform.runLater(op)
 
-private val timer: Timer by lazy { Timer(true) }
+private val runLaterTimer: Timer by lazy { Timer(true) }
 
 /**
  * Run the specified Runnable on the JavaFX Application Thread after a
@@ -173,7 +173,7 @@ private val timer: Timer by lazy { Timer(true) }
  */
 fun runLater(delay: Duration, op: () -> Unit): FXTimerTask {
     val task = FXTimerTask(op, timer)
-    timer.schedule(task, delay.toMillis().toLong())
+    runLaterTimer.schedule(task, delay.toMillis().toLong())
     return task
 }
 


### PR DESCRIPTION
In the current implementation, each call to runLater(duration) creates a new Timer, which in turn creates a new Thread. The threads never seem to get cleaned up, and eventually the process runs out of them.