### PR TITLE
Fix StackOverflow when `messagesNameProvider` returns the same value for all components.

### DIFF
--- a/src/main/java/tornadofx/Messages.kt
+++ b/src/main/java/tornadofx/Messages.kt
@@ -62,7 +62,7 @@ fun ResourceBundle.format(key: String, vararg fields: Any) =
 
 class FXPropertyResourceBundle(input: InputStreamReader): PropertyResourceBundle(input) {
     fun inheritFromGlobal() {
-        parent = FX.messages
+        parent = FX.messages.takeUnless(::equals)
     }
 
     /**


### PR DESCRIPTION
### Problem
This PR fixes a bug where if the `FX.messagesNameProvider` is set to return the same value for all Component classes including the global bundle, and a translation is missing a StackOverflow exception is thrown, because the parent bundle of any given bundle is itself.

### Example
Given this code:
```
FX.messagesNameProvider = { "bundles.MyMessages" }
```
When loading this view with no available translation:
```
import tornadofx.*

class SomeView : View() {
    override val root = borderpane {
        center {
            label(messages["some.key"])
        }
    }
}
```
The exception is thrown because the Bundle for this component `bundles.MyMessages` tries to get the translation from its parent, the global bundle, which in this case is also `bundles.MyMessages`, resulting in a infinite recursion.

### Solution
This is easily solved by not setting the parent bundle if the global bundle is the same as the current one.