### PR TITLE
Update to cellFormat

### DIFF
--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -441,15 +441,40 @@ fun <S, T> TableColumn<S, T>.cellDecorator(decorator: TableCell<S, T>.(T) -> Uni
     }
 }
 
-fun <S, T> TreeTableColumn<S, T>.cellFormat(formatter: (TreeTableCell<S, T>.(T) -> Unit)) {
-    cellFactory = Callback { column: TreeTableColumn<S, T> ->
-        object : TreeTableCell<S, T>() {
+fun <S, T> TableColumn<S, T>.cellFormat(formatter: (TableCell<S, T>.(T) -> Unit)) {
+    cellFactory = Callback { column: TableColumn<S, T> ->
+        object : TableCell<S, T>() {
+            private val defaultStyle = style
+
             override fun updateItem(item: T, empty: Boolean) {
                 super.updateItem(item, empty)
 
                 if (item == null || empty) {
                     text = null
                     graphic = null
+                    style = defaultStyle
+                } else {
+                    formatter(this, item)
+                }
+            }
+        }
+    }
+}
+
+fun <S, T> TreeTableColumn<S, T>.cellFormat(formatter: (TreeTableCell<S, T>.(T) -> Unit)) {
+    cellFactory = Callback { column: TreeTableColumn<S, T> ->
+        object : TreeTableCell<S, T>() {
+            private val defaultStyle = style
+            private val defaultStyleClass = listOf(*styleClass.toTypedArray())
+
+            override fun updateItem(item: T, empty: Boolean) {
+                super.updateItem(item, empty)
+
+                if (item == null || empty) {
+                    text = null
+                    graphic = null
+                    style = defaultStyle
+                    styleClass.s
                 } else {
                     formatter(this, item)
                 }

--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -441,30 +441,11 @@ fun <S, T> TableColumn<S, T>.cellDecorator(decorator: TableCell<S, T>.(T) -> Uni
     }
 }
 
-fun <S, T> TableColumn<S, T>.cellFormat(formatter: (TableCell<S, T>.(T) -> Unit)) {
-    cellFactory = Callback { column: TableColumn<S, T> ->
-        object : TableCell<S, T>() {
-            private val defaultStyle = style
-
-            override fun updateItem(item: T, empty: Boolean) {
-                super.updateItem(item, empty)
-
-                if (item == null || empty) {
-                    text = null
-                    graphic = null
-                    style = defaultStyle
-                } else {
-                    formatter(this, item)
-                }
-            }
-        }
-    }
-}
-
 fun <S, T> TreeTableColumn<S, T>.cellFormat(formatter: (TreeTableCell<S, T>.(T) -> Unit)) {
     cellFactory = Callback { column: TreeTableColumn<S, T> ->
         object : TreeTableCell<S, T>() {
             private val defaultStyle = style
+            // technically defined as TreeTableCell.DEFAULT_STYLE_CLASS = "tree-table-cell", but this is private
             private val defaultStyleClass = listOf(*styleClass.toTypedArray())
 
             override fun updateItem(item: T, empty: Boolean) {
@@ -474,7 +455,7 @@ fun <S, T> TreeTableColumn<S, T>.cellFormat(formatter: (TreeTableCell<S, T>.(T) 
                     text = null
                     graphic = null
                     style = defaultStyle
-                    styleClass.s
+                    styleClass.setAll(defaultStyleClass)
                 } else {
                     formatter(this, item)
                 }


### PR DESCRIPTION
Rather than an additional callback, it might be better to simply reset
the cell's `style` and `styleClass` properties to their defaults.

Now that we're on this topic anyway, I couldn't find `cellFormat` for a
regular `TableColumn` but I did find `SmartTableCell` in `TableView`,
which has a similar style reset in it's `updateItem`, except resetting
the `styleClass` list. Should I create a PR for that, too?