### PR TITLE
Call onDock on a scene's root View when showing its window

### DIFF
--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -94,8 +94,12 @@ open class App(open val primaryView: KClass<out UIComponent> = NoPrimaryViewSpec
                 view.onBeforeShow()
                 onBeforeShow(view)
                 view.muteDocking = false
-                if (view !is NoPrimaryViewSpecified && shouldShowPrimaryStage()) show()
-                view.callOnDock()
+                // No need to call view.callOnDock() if show() is called since it
+                // will be called by the stage's showingProperty listener
+                if (view !is NoPrimaryViewSpecified && shouldShowPrimaryStage())
+                    show()
+                else
+                    view.callOnDock()
                 stage.aboutToBeShown = false
             }
             FX.initialized.value = true

--- a/src/main/java/tornadofx/Component.kt
+++ b/src/main/java/tornadofx/Component.kt
@@ -521,10 +521,11 @@ abstract class UIComponent(viewTitle: String? = "", icon: Node? = null) : Compon
             if (modalStage != null || root.parent != null) return@addListener
             if (newParent == null && oldParent != null && isDocked) callOnUndock()
             if (newParent != null && newParent != oldParent && !isDocked) {
-                // Call undock when window closes
+                // Calls dock or undock when window opens or closes
                 newParent.windowProperty().onChangeOnce {
                     it?.showingProperty()?.onChange {
                         if (!it && isDocked) callOnUndock()
+                        if (it && !isDocked) callOnDock()
                     }
                 }
                 callOnDock()


### PR DESCRIPTION
This addresses #918 where onUndock would be called on a scene's root View when hiding a window, but onDock never gets subsequently called upon showing it.