### PR TITLE
New and old value can be null in ChangeListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `App.scope` is overridable
 - `DefaultScope` deprecated, use `FX.defaultScope` instead
 - The Workspace inside the `scope` of a UIComponents will assume the Workspace it is docked in (https://github.com/edvin/tornadofx/issues/806)
+- ChangeListener values are now nullable
 - Kotlin 1.2.70
 
 ### Additions

--- a/src/main/java/tornadofx/Lib.kt
+++ b/src/main/java/tornadofx/Lib.kt
@@ -221,7 +221,7 @@ fun Clipboard.putString(value: String) = setContent { putString(value) }
 fun Clipboard.putFiles(files: MutableList<File>) = setContent { putFiles(files) }
 fun Clipboard.put(dataFormat: DataFormat, value: Any) = setContent { put(dataFormat, value) }
 
-inline fun <T> ChangeListener(crossinline listener: (observable: ObservableValue<out T>?, oldValue: T, newValue: T) -> Unit): ChangeListener<T> =
+inline fun <T> ChangeListener(crossinline listener: (observable: ObservableValue<out T>?, oldValue: T?, newValue: T?) -> Unit): ChangeListener<T> =
         javafx.beans.value.ChangeListener<T> { observable, oldValue, newValue -> listener(observable, oldValue, newValue) }
 
 /**


### PR DESCRIPTION
This probably counts as a breaking change, but it saves getting caught out when you forget.

Would be nice to backport as well, but not sure if you want to change the API in the stable.
