### PR TITLE
Add splitmenubutton builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added `cubiccurveTo` builder (https://github.com/edvin/tornadofx/issues/911)
 - onLeftClick() and onRightClick()
 - Convenience function builders for SimpleXXXProperty classes (https://github.com/edvin/tornadofx/pull/935)
+- Added `splitmenubutton` builder 
 
 ## [1.7.18]
 

--- a/src/main/java/tornadofx/Controls.kt
+++ b/src/main/java/tornadofx/Controls.kt
@@ -204,6 +204,11 @@ fun EventTarget.menubutton(text: String = "", graphic: Node? = null, op: MenuBut
     if (graphic != null) it.graphic = graphic
 }
 
+fun EventTarget.splitmenubutton(text: String? = null, graphic: Node? = null, op: SplitMenuButton.() -> Unit = {}) = SplitMenuButton().attachTo(this, op) {
+    if (text != null) it.text = text
+    if (graphic != null) it.graphic = graphic
+}
+
 fun EventTarget.button(text: ObservableValue<String>, graphic: Node? = null, op: Button.() -> Unit = {}) = Button().attachTo(this, op) {
     it.textProperty().bind(text)
     if (graphic != null) it.graphic = graphic

--- a/src/test/kotlin/tornadofx/tests/ControlsTest.kt
+++ b/src/test/kotlin/tornadofx/tests/ControlsTest.kt
@@ -98,4 +98,15 @@ class ControlsTest {
         Assert.assertEquals(24.0, slider.min, 10e-5)
         Assert.assertEquals(42.0, slider.max, 10e-5)
     }
+
+    @Test
+    fun testSplitMenuButton() {
+        val view = TestView()
+        val button = view.splitmenubutton("Text") {
+            item("Item Name")
+        }
+
+        Assert.assertEquals(button.text, "Text")
+        Assert.assertEquals(button.items.first().text, "Item Name")
+    }
 }


### PR DESCRIPTION
There was no builder method for `javafx.scene.control.SplitMenuButton`. This PR adds one.