### PR TITLE
Fix EventBus subscriptions leak, see #1009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Changes
 
 - `openInternalWindow()` was made public (https://github.com/edvin/tornadofx/issues/989)
+- `Scope.deregister()` clears EventBus subscriptions associated with a particular scope
+- `App.stop()` clears all EventBus subscriptions
 
 ### Additions
 

--- a/src/main/java/tornadofx/App.kt
+++ b/src/main/java/tornadofx/App.kt
@@ -5,6 +5,7 @@ import javafx.application.Platform
 import javafx.scene.Scene
 import javafx.scene.image.Image
 import javafx.stage.Stage
+import tornadofx.FX.Companion.eventbus
 import tornadofx.FX.Companion.inheritParamHolder
 import tornadofx.FX.Companion.inheritScopeHolder
 import tornadofx.FX.Companion.primaryStage
@@ -139,6 +140,7 @@ open class App(open val primaryView: KClass<out UIComponent> = NoPrimaryViewSpec
         primaryStage.unhookGlobalShortcuts()
         view.unInit()
         view.removeFromParent()
+        eventbus.clear()
         scope.deregister()
         shutdownThreadPools()
         inheritParamHolder.remove()

--- a/src/main/java/tornadofx/EventBus.kt
+++ b/src/main/java/tornadofx/EventBus.kt
@@ -122,4 +122,18 @@ class EventBus {
         }
     }
 
+    internal fun clear() {
+        subscriptions.clear()
+        eventScopes.clear()
+    }
+
+    internal fun unsubscribeAll(scope: Scope) {
+        val scopedContexts: Map<EventContext.(FXEvent) -> Unit, Scope> = eventScopes.filter { it.value == scope }
+        val registrations = mutableListOf<FXEventRegistration>()
+        subscriptions.forEach { (_, subscriptionRegistrations) ->
+            registrations += subscriptionRegistrations.filter { scopedContexts.containsKey(it.action) }
+        }
+        registrations.forEach { it.unsubscribe() }
+    }
+
 }

--- a/src/main/java/tornadofx/FX.kt
+++ b/src/main/java/tornadofx/FX.kt
@@ -63,6 +63,7 @@ open class Scope() {
         FX.primaryStages.remove(this)
         FX.applications.remove(this)
         FX.components.remove(this)
+        FX.eventbus.unsubscribeAll(this)
     }
 
     // Fix the component types to this scope


### PR DESCRIPTION
The EventBus was holding references to subscriptions beyond the app lifecycle. This was a problem for my test automation, which was starting and stopping multiple `tornadofx.App` instances inside a single process. Stale subscriptions were getting called and completely wreaking havoc.

This PR makes two changes:
- Remove the EventBus subscriptions associated to a `Scope` when it is de-registered.
- Clear the EventBus entirely when an App stops.