### PR TITLE
add ability to setup comparator to SortedFilteredList, added example

### DIFF
--- a/src/main/java/tornadofx/Lib.kt
+++ b/src/main/java/tornadofx/Lib.kt
@@ -38,9 +38,11 @@ class SortedFilteredList<T>(
         val items: ObservableList<T> = FXCollections.observableArrayList(),
         initialPredicate: (T) -> Boolean = { true },
         val filteredItems: FilteredList<T> = FilteredList(items, initialPredicate),
+        val comparatorProperty: ObservableValue<java.util.Comparator<T>>? = null,
         val sortedItems: SortedList<T> = SortedList(filteredItems)) : ObservableList<T> {
 
     init {
+        comparatorProperty?.let {  sortedItems.comparatorProperty().bind(it)}
         items.onChange { refilter() }
     }
 

--- a/src/test/kotlin/tornadofx/testapps/SortableListViewExample.kt
+++ b/src/test/kotlin/tornadofx/testapps/SortableListViewExample.kt
@@ -1,0 +1,33 @@
+package tornadofx.testapps
+
+import javafx.beans.property.SimpleObjectProperty
+import tornadofx.*
+import java.util.*
+import kotlin.math.roundToInt
+
+
+class SortableListViewExample : View("Sortable List View") {
+    private val comparatorProperty = SimpleObjectProperty<Comparator<Int>>(compareBy { it })
+    private val numbers = SortedFilteredList<Int>(comparatorProperty = comparatorProperty)
+
+    override val root = vbox {
+
+        button("Add number").action {
+            numbers.add((Math.random() * 100).roundToInt())
+        }
+        button("Reverse Order").action {
+            comparatorProperty.set(comparatorProperty.get().reversed())
+        }
+        button("Show numbers that are  greater than  50").action {
+            numbers.predicate = { it > 50 }
+        }
+        button("Show all numbers").action {
+            numbers.predicate = { true }
+        }
+
+        scrollpane {
+            listview(numbers) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
It looks like that SortedFilteredList doesn't have ability to setup comparator.