### PR TITLE
TableView's rowExpander incorrectly renders on the jdk10 branch

### DIFF
--- a/src/main/java/tornadofx/skin/tablerow/ExpandableTableRowSkin.java
+++ b/src/main/java/tornadofx/skin/tablerow/ExpandableTableRowSkin.java
@@ -45,10 +45,7 @@ public final class ExpandableTableRowSkin<S> extends TableRowSkin<S> {
 
     protected double computePrefHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
         tableRowPrefHeight = super.computePrefHeight(width, topInset, rightInset, bottomInset, leftInset);
-        if (getExpanded() && getContent() != null) {
-            tableRowPrefHeight += getContent().prefHeight(width);
-        }
-        return tableRowPrefHeight;
+        return (getExpanded() && getContent() != null) ? tableRowPrefHeight + getContent().prefHeight(width) : tableRowPrefHeight;
     }
 
     protected void layoutChildren(double x, double y, double w, double h) {


### PR DESCRIPTION
TableView's rowExpander incorrectly renders on the jdk10 branch
because ExpandableTableRowSkin.java's logic was incorrectly translated when converting from Kotlin source to Java

tableRowPrefHeight should not add the children content size to it, as this affects the calculation in layoutChildren
