### PR TITLE
Fix for #1069

### DIFF
--- a/src/main/java/tornadofx/TableView.kt
+++ b/src/main/java/tornadofx/TableView.kt
@@ -77,6 +77,7 @@ open class SmartTableCell<S, T>(val scope: Scope = FX.defaultScope, val owningCo
             text = null
             graphic = null
             style = null
+            styleClass.clear()
             clearCellFragment()
         } else {
             FX.ignoreParentBuilder = FX.IgnoreParentBuilder.Once


### PR DESCRIPTION
`SmartTableCell` now resets `styleClass` when `updateItem` is called
with a `null` item, or when `empty = true`.