### PR TITLE
Fix for #1069

### DIFF
--- a/src/main/java/tornadofx/TableView.kt
+++ b/src/main/java/tornadofx/TableView.kt
@@ -77,6 +77,7 @@ open class SmartTableCell<S, T>(val scope: Scope = FX.defaultScope, val owningCo
             text = null
             graphic = null
             style = null
+            styleClass.clear()
             clearCellFragment()
         } else {
             FX.ignoreParentBuilder = FX.IgnoreParentBuilder.Once

--- a/src/main/java/tornadofx/TableView.kt
+++ b/src/main/java/tornadofx/TableView.kt
@@ -72,12 +72,7 @@ open class SmartTableCell<S, T>(val scope: Scope = FX.defaultScope, val owningCo
         super.updateItem(item, empty)
 
         if (item == null || empty) {
-            textProperty().unbind()
-            graphicProperty().unbind()
-            text = null
-            graphic = null
-            style = null
-            styleClass.clear()
+            cleanUp()
             clearCellFragment()
         } else {
             FX.ignoreParentBuilder = FX.IgnoreParentBuilder.Once
@@ -100,6 +95,15 @@ open class SmartTableCell<S, T>(val scope: Scope = FX.defaultScope, val owningCo
             }
             cellFormat?.invoke(this, item)
         }
+    }
+
+    private fun cleanUp() {
+        textProperty().unbind()
+        graphicProperty().unbind()
+        text = null
+        graphic = null
+        style = null
+        styleClass.clear()
     }
 
     private fun clearCellFragment() {


### PR DESCRIPTION
`SmartTableCell` now resets `styleClass` when `updateItem` is called
with a `null` item, or when `empty = true`.

Goody, this feels better!

On a related note, I saw that you use a utility method `cleanUp` in `SmartTreeCell`, but not in the two others. I could clean that up, while I'm at it, if you want. Would you let me know in a reply to the PR?