### PR TITLE
Add clipping to view transitions

### DIFF
--- a/src/main/java/tornadofx/Animation.kt
+++ b/src/main/java/tornadofx/Animation.kt
@@ -15,6 +15,7 @@ import javafx.scene.layout.Pane
 import javafx.scene.layout.StackPane
 import javafx.scene.paint.Color
 import javafx.scene.paint.Paint
+import javafx.scene.shape.Rectangle
 import javafx.scene.shape.Shape
 import javafx.scene.transform.Rotate
 import javafx.util.Duration
@@ -520,7 +521,7 @@ abstract class ViewTransition {
         this.setup = setup
     }
 
-    internal fun call(current: Node, replacement: Node, attach: (Node) -> Unit) {
+    internal fun call(current: Node, replacement: Node, clip: Boolean, attach: (Node) -> Unit) {
         current.isTransitioning = true
         replacement.isTransitioning = true
         val currentUIComponent = current.properties[UI_COMPONENT_PROPERTY] as? UIComponent
@@ -529,6 +530,12 @@ abstract class ViewTransition {
         replacementUIComponent?.muteDocking = true
 
         val stack = stack(current, replacement)
+        if (clip) {
+            stack.clip = Rectangle().apply {
+                widthProperty().bind(stack.widthProperty())
+                heightProperty().bind(stack.heightProperty())
+            }
+        }
         stack.setup()
         attach(stack)
 

--- a/src/main/java/tornadofx/Component.kt
+++ b/src/main/java/tornadofx/Component.kt
@@ -1139,8 +1139,9 @@ abstract class UIComponent(viewTitle: String? = "", icon: Node? = null) : Compon
             replacement: UIComponent,
             transition: ViewTransition? = null,
             sizeToScene: Boolean = false,
-            centerOnScreen: Boolean = false
-    ) = root.replaceWith(replacement.root, transition, sizeToScene, centerOnScreen) {
+            centerOnScreen: Boolean = false,
+            clip: Boolean = true
+    ) = root.replaceWith(replacement.root, transition, sizeToScene, centerOnScreen, clip) {
         if (root == root.scene?.root) (root.scene.window as? Stage)?.titleProperty()?.cleanBind(replacement.titleProperty)
     }
 

--- a/src/main/java/tornadofx/Nodes.kt
+++ b/src/main/java/tornadofx/Nodes.kt
@@ -936,7 +936,14 @@ internal var Node.isTransitioning: Boolean
  * @param transition The [ViewTransition] used to animate the transition
  * @return Whether or not the transition will run
  */
-fun Node.replaceWith(replacement: Node, transition: ViewTransition? = null, sizeToScene: Boolean = false, centerOnScreen: Boolean = false, onTransit: () -> Unit = {}): Boolean {
+fun Node.replaceWith(
+    replacement: Node,
+    transition: ViewTransition? = null,
+    sizeToScene: Boolean = false,
+    centerOnScreen: Boolean = false,
+    clip: Boolean = true,
+    onTransit: () -> Unit = {}
+): Boolean {
     if (isTransitioning || replacement.isTransitioning) {
         return false
     }
@@ -952,7 +959,7 @@ fun Node.replaceWith(replacement: Node, transition: ViewTransition? = null, size
         replacement.uiComponent<UIComponent>()?.properties?.put("tornadofx.scene", scene)
 
         if (transition != null) {
-            transition.call(this, replacement) {
+            transition.call(this, replacement, clip) {
                 scene.root = it as Parent
                 if (sizeToScene) scene.window.sizeToScene()
                 if (centerOnScreen) scene.window.centerOnScreen()
@@ -995,7 +1002,7 @@ fun Node.replaceWith(replacement: Node, transition: ViewTransition? = null, size
         }
 
         if (transition != null) {
-            transition.call(this, replacement, attach)
+            transition.call(this, replacement, clip, attach)
         } else {
             removeFromParent()
             replacement.removeFromParent()


### PR DESCRIPTION
It's clipped by default, but can be turned off with a simple Boolean flag.

Note that if the user wants more complicated clipping, that is still possible by overriding the `setup()` function. This just sets a useful default.