### PR TITLE
Always return false for `FX.osgiAvailable`

### DIFF
--- a/src/main/java/tornadofx/FX.kt
+++ b/src/main/java/tornadofx/FX.kt
@@ -153,6 +153,8 @@ class FX {
         var layoutDebuggerShortcut: KeyCodeCombination? = KeyCodeCombination(KeyCode.J, KeyCodeCombination.META_DOWN, KeyCodeCombination.ALT_DOWN)
         var osgiDebuggerShortcut: KeyCodeCombination? = KeyCodeCombination(KeyCode.O, KeyCodeCombination.META_DOWN, KeyCodeCombination.ALT_DOWN)
 
+        val osgiAvailable: Boolean get() = false
+        /* TODO: Uncomment when OSGi support is working again
         val osgiAvailable: Boolean by lazy {
             try {
                 Class.forName("org.osgi.framework.FrameworkUtil")
@@ -161,6 +163,7 @@ class FX {
                 false
             }
         }
+        */
 
         private val _locale: SimpleObjectProperty<Locale> = object : SimpleObjectProperty<Locale>() {
             override fun invalidated() = loadMessages()


### PR DESCRIPTION
This is a workaround for the CSS Url Handler not being properly
installed. I left a TODO for this to be revisited when OSGi support is
working correctly again.

_Closes #1097_