### PR TITLE
changed the pom to only use gpg sign when the deploy command of maven…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>install</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>


### PR DESCRIPTION
somehow the gpg is always connected to the install phase in maven instead of deploy. So this one word fix is needed (again :) )