### PR TITLE
Remove non-nullable bound from runAsyncWithProgress

### DIFF
--- a/src/main/java/tornadofx/Async.kt
+++ b/src/main/java/tornadofx/Async.kt
@@ -238,7 +238,7 @@ fun Node.runAsyncWithProgress(latch: CountDownLatch, timeout: Duration? = null, 
  * The default progress node is a ProgressIndicator that fills the same
  * client area as the parent. You can swap the progress node for any Node you like.
  */
-fun <T : Any> Node.runAsyncWithProgress(progress: Node = ProgressIndicator(), op: () -> T): Task<T> {
+fun <T> Node.runAsyncWithProgress(progress: Node = ProgressIndicator(), op: () -> T): Task<T> {
     if (this is Labeled) {
         val oldGraphic = graphic
         (progress as? Region)?.setPrefSize(16.0, 16.0)


### PR DESCRIPTION
Fixes #1128.

I don't have the time to set up a development environment right now so I just edited it in the github UI, meaning there could be very obvious and dumb mistakes/oversights. If tests complain I'll fix it up.