### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ cache:
 deploy:
   # Deploy snapshots & releases on every commit made to master
   - provider: script
-    script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy"
+    script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy -Dmaven.test.skip=true -Dgpg.skip=true"
     skip_cleanup: true
     on:
       all_branches: true


### PR DESCRIPTION
All current Travis CI jobs are failing with the same error:

> The job exceeded the maximum log length, and has been terminated.

In deploy step, `tests` run again causing the same output twice. Moreover, we do not have keys to sign artifacts in place. Therefore, this PR removes both these steps while deploying.