### PR TITLE
Add destructuring operators to MapChangeListener

### DIFF
--- a/src/main/java/tornadofx/Collections.kt
+++ b/src/main/java/tornadofx/Collections.kt
@@ -575,6 +575,10 @@ class SetConversionListener<SourceType, TargetType>(targetList: MutableList<Targ
     }
 }
 
+operator fun <K, V> MapChangeListener.Change<K, V>.component1(): K = key;
+operator fun <K, V> MapChangeListener.Change<K, V>.component2(): V? = valueAdded;
+operator fun <K, V> MapChangeListener.Change<K, V>.component3(): V? = valueRemoved;
+
 fun <T> ObservableList<T>.invalidate() {
     if (isNotEmpty()) this[0] = this[0]
 }


### PR DESCRIPTION
I added destructuring operators to `MapChangeListener` to allow usage like this:

```kt
observableMap.addListener(MapChangeListener { (key, added, removed) ->
	// exciting stuff
})
```

This might be more controversial than #1141 since the order is relatively arbitrary (although it feels quite natural to me).
If this addition is not desired feel free to close this pull request, otherwise I should probably also add these operators to the other collection types' listeners.