### PR TITLE
Fixed TornadoFX Guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You also need a full rebuild of your code after a version upgrade. If you run in
 ## Getting started
 
 - [Screencasts](https://www.youtube.com/user/MrEdvinsyse)
-- [Guide](https://edvin.gitbooks.io/tornadofx-guide/content/) We are gradually migrating all information from the Wiki into the Guide
+- [Guide](https://docs.tornadofx.io/) We are gradually migrating all information from the Wiki into the Guide
 - [KDocs](https://tornadofx.io/dokka/tornadofx/tornadofx/index.html)
 - [Wiki](https://github.com/edvin/tornadofx/wiki)
 - [Slack](https://kotlinlang.slack.com/messages/tornadofx/details/)


### PR DESCRIPTION
TornadoFX Guide link now targets to https://docs.tornadofx.io/
according to https://github.com/edvin/tornadofx/issues/1190