### PR TITLE
[#1318] Fix leaking fragments

### DIFF
--- a/src/main/java/tornadofx/Component.kt
+++ b/src/main/java/tornadofx/Component.kt
@@ -528,61 +528,53 @@ abstract class UIComponent(viewTitle: String? = "", icon: Node? = null) : Compon
         properties["tornadofx.closeable"] = SimpleBooleanProperty(false)
     }
 
-    private val rootParentChangeListener: ChangeListener<Parent>
-        get() {
-            val key = "tornadofx.rootParentChangeListener"
-            if (properties[key] == null) {
-                properties[key] = ChangeListener<Parent> { _, oldParent, newParent ->
-                    if (modalStage != null) return@ChangeListener
-                    if (newParent == null && oldParent != null && isDocked) callOnUndock()
-                    if (newParent != null && newParent != oldParent && !isDocked) {
-                        callOnDock()
-                        // Call `onTabSelected` if/when we are connected to a Tab and it's selected
-                        // Note that this only works for builder constructed tabpanes
-                        owningTab?.let {
-                            it.selectedProperty()?.onChange { if (it) onTabSelected() }
-                            if (it.isSelected) onTabSelected()
-                        }
-                    }
+    private val rootParentChangeListener: ChangeListener<Parent> by lazy {
+        ChangeListener<Parent> { _, oldParent, newParent ->
+            if (modalStage != null) return@ChangeListener
+            if (newParent == null && oldParent != null && isDocked) callOnUndock()
+            if (newParent != null && newParent != oldParent && !isDocked) {
+                callOnDock()
+                // Call `onTabSelected` if/when we are connected to a Tab and it's selected
+                // Note that this only works for builder constructed tabpanes
+                owningTab?.let {
+                    it.selectedProperty()?.onChange { if (it) onTabSelected() }
+                    if (it.isSelected) onTabSelected()
                 }
             }
-            return properties[key] as ChangeListener<Parent>
         }
+    }
 
-    private val rootSceneChangeListener: ChangeListener<Scene>
-        get() {
-            val key = "tornadofx.rootSceneChangeListener"
-            if (properties[key] == null) {
-                properties[key] = ChangeListener<Scene> { _, oldParent, newParent ->
-                    if (modalStage != null || root.parent != null) return@ChangeListener
-                    if (newParent == null && oldParent != null && isDocked) callOnUndock()
-                    if (newParent != null && newParent != oldParent && !isDocked) {
-                        // Calls dock or undock when window opens or closes
-                        newParent.windowProperty().onChangeOnce {
-                            it?.showingProperty()?.addListener(rootSceneWindowShowingPropertyChangeListener)
-                        }
-                        callOnDock()
-                    }
-                }
-            }
-            return properties[key] as ChangeListener<Scene>
-        }
+    private val rootSceneChangeListener: ChangeListener<Scene> by lazy {
+        ChangeListener<Scene> { _, oldParent, newParent ->
+            val key = "tornadofx.rootSceneWindowPropertyChangeListener"
 
-    private val rootSceneWindowShowingPropertyChangeListener: ChangeListener<Boolean>
-        get() {
-            val key = "tornadofx.rootSceneWindowShowingPropertyChangeListener"
-            if (properties[key] == null) {
-                properties[key] = ChangeListener<Boolean> { property, oldValue, newValue ->
-                    if (!isInitialized) {
-                        property.removeListener(rootSceneWindowShowingPropertyChangeListener)
-                        return@ChangeListener
-                    }
-                    if (!newValue && isDocked) callOnUndock()
-                    if (newValue && !isDocked) callOnDock()
+            if (modalStage != null || root.parent != null) return@ChangeListener
+            if (newParent == null && oldParent != null && isDocked) {
+                (properties[key] as? ChangeListener<Window>)?.run {
+                    oldParent.windowProperty().removeListener(this)
                 }
+                callOnUndock()
             }
-            return properties[key] as ChangeListener<Boolean>
+            if (newParent != null && newParent != oldParent && !isDocked) {
+                // Calls dock or undock when window opens or closes
+                properties[key] = newParent.windowProperty().onChangeOnce {
+                    it?.showingProperty()?.addListener(rootSceneWindowShowingPropertyChangeListener)
+                }
+                callOnDock()
+            }
         }
+    }
+
+    private val rootSceneWindowShowingPropertyChangeListener: ChangeListener<Boolean> by lazy {
+        ChangeListener<Boolean> { property, oldValue, newValue ->
+            if (!isInitialized) {
+                property.removeListener(rootSceneWindowShowingPropertyChangeListener)
+                return@ChangeListener
+            }
+            if (!newValue && isDocked) callOnUndock()
+            if (newValue && !isDocked) callOnDock()
+        }
+    }
 
     internal fun init() {
         if (isInitialized) return

--- a/src/main/java/tornadofx/Lib.kt
+++ b/src/main/java/tornadofx/Lib.kt
@@ -233,7 +233,7 @@ inline fun <T> ChangeListener(crossinline listener: (observable: ObservableValue
  * Listen for changes to this observable. Optionally only listen x times.
  * The lambda receives the changed value when the change occurs, which may be null,
  */
-fun <T> ObservableValue<T>.onChangeTimes(times: Int, op: (T?) -> Unit) {
+fun <T> ObservableValue<T>.onChangeTimes(times: Int, op: (T?) -> Unit): ChangeListener<T> {
     var counter = 0
     val listener = object : ChangeListener<T> {
         override fun changed(observable: ObservableValue<out T>?, oldValue: T, newValue: T) {
@@ -244,9 +244,10 @@ fun <T> ObservableValue<T>.onChangeTimes(times: Int, op: (T?) -> Unit) {
         }
     }
     addListener(listener)
+    return listener
 }
 
-fun <T> ObservableValue<T>.onChangeOnce(op: (T?) -> Unit) = onChangeTimes(1, op)
+fun <T> ObservableValue<T>.onChangeOnce(op: (T?) -> Unit): ChangeListener<T>  = onChangeTimes(1, op)
 
 fun <T> ObservableValue<T>.onChange(op: (T?) -> Unit) = apply { addListener { o, oldValue, newValue -> op(newValue) } }
 fun ObservableBooleanValue.onChange(op: (Boolean) -> Unit) = apply { addListener { o, old, new -> op(new ?: false) } }


### PR DESCRIPTION
Fix leaking Fragments.

Remove windowProperty() listener before undocking.

And some refactoring for listeners registering for dock/undock.
Move listener holders from properties (map) to backing field by lazy() kotlin to reduce indent and lines.

Even the fixes pass the test cases, I couldn't find a way to check memory leaking.
It should be verified manually using jmap histogram dump.

Please review the code.